### PR TITLE
fix: Fix StartStreaming command

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -172,3 +172,6 @@ https://github.com/hashicorp/go-multierror/blob/master/LICENSE
 
 xfrr/goffmpeg (MIT) https://github.com/xfrr/goffmpeg
 https://github.com/xfrr/goffmpeg/blob/master/LICENSE
+
+stretchr/testify (MIT) https://github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Supported Input options:
 - **InputImageSize**: Specifies the image size of the camera. The format is `wxh`, for example "640x480". (default - automatically selected by FFmpeg)
 - **InputPixelFormat**: Set the preferred pixel format (for raw video). (default - automatically selected by FFmpeg)
 
+> *Note: If the given option value is not supported by the device, FFmpeg will automatically select the best one supported by the device.
+
 Supported Output options:
 - **OutputFrames**: Set the number of video frames to output. (default - no limitation on frames)
 - **OutputFps**: Duplicate or drop input frames to achieve constant output frame rate fps. (default - same as InputFps)
@@ -128,6 +130,8 @@ Supported Output options:
 
 You can also set default values for these options by adding additional attributes to the device resource **StartStreaming**.
 The attribute name consists of a prefix "default" and the option name.
+
+
 
 For example:
 ```yaml

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/edgexfoundry/device-sdk-go/v2 v2.1.0
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.1.0
+	github.com/stretchr/testify v1.7.0
 	github.com/vladimirvivien/go4vl v0.0.2-0.20211216162907-40b41ba86c5c
 	github.com/xfrr/goffmpeg v0.0.0-20210624103149-5ca2d3062daf
 )

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -57,6 +57,15 @@ const (
 	FFmpegVCodec      = "-vcodec"
 	FFmpegInputFormat = "-input_format"
 
+	// FFmpeg option values
+	FFmpegPixFmtRGB24   = "rgb24"
+	FFmpegPixFmtGray    = "gray"
+	FFmpegPixelFmtYUYV  = "yuyv422"
+	FFmpegPixelFmtMJPEG = "mjpeg"
+
+	// Input option names
+	InputPixelFormat = "InputPixelFormat"
+
 	// udev device properties
 	UdevSerialShort = "ID_SERIAL_SHORT"
 	UdevV4lProduct  = "ID_V4L_PRODUCT"

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -32,6 +32,7 @@ type Device struct {
 }
 
 type streamingStatus struct {
+	Error              string
 	IsStreaming        bool
 	OutputFrames       string
 	InputFps           string
@@ -55,9 +56,14 @@ func (dev *Device) StartStreaming(ctx context.Context, cancel context.CancelFunc
 	return errChan, nil
 }
 
-func (dev *Device) StopStreaming() {
+func (dev *Device) StopStreaming(err error) {
 	dev.mutex.Lock()
 	defer dev.mutex.Unlock()
+	if err != nil {
+		dev.streamingStatus.Error = err.Error()
+	} else {
+		dev.streamingStatus.Error = ""
+	}
 	if dev.streamingStatus.IsStreaming {
 		dev.cancelFunc()
 		dev.streamingStatus.IsStreaming = false

--- a/internal/driver/ffmpeg_test.go
+++ b/internal/driver/ffmpeg_test.go
@@ -1,0 +1,38 @@
+package driver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vladimirvivien/go4vl/v4l2"
+)
+
+func TestParseOptionValuePixelFormat(t *testing.T) {
+	tests := []struct {
+		name          string
+		value         interface{}
+		expectedValue string
+		expectErr     bool
+	}{
+		{"rgb24 (go4vl)", v4l2.PixelFormats[v4l2.PixFmtRGB24], FFmpegPixFmtRGB24, false},
+		{"rgb24 (FFmpeg)", FFmpegPixFmtRGB24, FFmpegPixFmtRGB24, false},
+		{"gray (go4vl)", v4l2.PixelFormats[v4l2.PixFmtGrey], FFmpegPixFmtGray, false},
+		{"gray (FFmpeg)", FFmpegPixFmtGray, FFmpegPixFmtGray, false},
+		{"yuyv (go4vl)", v4l2.PixelFormats[v4l2.PixelFmtYUYV], FFmpegPixelFmtYUYV, false},
+		{"yuyv (FFmpeg)", FFmpegPixelFmtYUYV, FFmpegPixelFmtYUYV, false},
+		{"mjpeg (go4vl)", v4l2.PixelFormats[v4l2.PixelFmtMJPEG], FFmpegPixelFmtMJPEG, false},
+		{"mjpeg (FFmpeg)", FFmpegPixelFmtMJPEG, FFmpegPixelFmtMJPEG, false},
+		{"unsupported value", "rgb8", "", true},
+		{"wrong value type", 123, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, err := parseOptionValue(InputPixelFormat, tt.value)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, value, tt.expectedValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
- StartStreaming command will fail if users use the Pixel Format obtained by GetDataFormat command
- Users cannot see the error message if StartStreaming fails

## Issue Number:
fix #9

## What is the new behavior?
- Add checks and conversions for the input Pixel Format value.
- If StartStreaming fails, the error message will be cached. To see the error message, use the StreamingStatus command.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?
https://github.com/stretchr/testify for unit test

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information