### PR TITLE
fix: return command execution errors

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -615,10 +615,10 @@ func getQueryParameters(req sdkModels.CommandRequest) (url.Values, errors.EdgeX)
 // getUSBDeviceIdInfo returns the serial number and the card name of the device on the specified path
 func getUSBDeviceIdInfo(path string) (cardName string, serialNumber string, err error) {
 	cmd := exec.Command("udevadm", "info", "--query=property", path)
-	output, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", "", errors.NewCommonEdgeX(errors.KindServerError,
-			fmt.Sprintf("failed to run command: %s", cmd.String()), err)
+			fmt.Sprintf("failed to run command: %s: %s", cmd.String(), output), err)
 	}
 	props := strings.Split(string(output), "\n")
 	m := make(map[string]string, len(props))


### PR DESCRIPTION
From unresolved review comment:
- https://github.com/edgexfoundry/device-usb-camera/pull/11#discussion_r859906148

This command execution doesn't capture standard errors nor does it return the standard output on error. Changed to use [CombinedOutput()](https://pkg.go.dev/os/exec#Cmd.CombinedOutput) and return the output to the caller on error.

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information