### PR TITLE
fix: pass missing device name to error formatter

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -521,7 +521,7 @@ func (d *Driver) startStreaming(device *Device) errors.EdgeX {
 		select {
 		case err := <-errChan:
 			device.StopStreaming()
-			d.lc.Errorf("the video streaming process for device %s has stopped, error: %s", err)
+			d.lc.Errorf("the video streaming process for device %s has stopped, error: %s", device.name, err)
 			d.wg.Done()
 			return
 		case <-device.ctx.Done():


### PR DESCRIPTION
Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
```
level=ERROR ts=2022-05-19T11:48:32.774545384Z app=device-usb-camera source=driver.go:524 msg="the video streaming process for device Failed Finish FFMPEG ([-nostats -loglevel 0 -y -s 640x480 -i /dev/video0 -qscale 5 -f rtsp -hls_list_size 0 rtsp://localhost:8554/stream/Logitech_StreamCam-4B17BE45]) with exit status 1 message   has stopped, error: %!s(MISSING)"
```

## Issue Number:
Related to #23

## What is the new behavior?
```
level=ERROR ts=2022-05-19T11:56:04.907383438Z app=device-usb-camera source=driver.go:524 msg="the video streaming process for device Logitech_StreamCam-4B17BE45 has stopped, error: Failed Finish FFMPEG ([-nostats -loglevel 0 -y -s 640x480 -i /dev/video0 -qscale 5 -f rtsp -hls_list_size 0 rtsp://localhost:8554/stream/Logitech_StreamCam-4B17BE45]) with exit status 1 message  "
```

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information