### PR TITLE
build: set rtsp-simple-server docker image base to v0.18.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY . .
 
 RUN ${MAKE}
 
-FROM aler9/rtsp-simple-server AS rtsp
+FROM aler9/rtsp-simple-server:v0.18.4 AS rtsp
 
 FROM alpine:3.15
 


### PR DESCRIPTION
The base Docker image for [rtsp-simple-server](https://github.com/aler9/rtsp-simple-server) is using the latest tag. This PR fixes it to the latest version.

https://hub.docker.com/r/aler9/rtsp-simple-server/tags

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information