### PR TITLE
fix: Add `ID_SERIAL` as a fallback if `ID_SERIAL_SHORT` is not set

### DIFF
--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -57,5 +57,6 @@ const (
 
 	// udev device properties
 	UdevSerialShort = "ID_SERIAL_SHORT"
+	UdevSerial      = "ID_SERIAL"
 	UdevV4lProduct  = "ID_V4L_PRODUCT"
 )

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -632,10 +632,14 @@ func getUSBDeviceIdInfo(path string) (cardName string, serialNumber string, err 
 		}
 	}
 	cardName = m[UdevV4lProduct]
-	serialNumber = m[UdevSerialShort]
 	if len(cardName) == 0 {
 		return "", "", errors.NewCommonEdgeX(errors.KindServerError,
 			fmt.Sprintf("could not find the card name of the device on the specified path %s", path), nil)
+	}
+	if len(m[UdevSerialShort]) > 0 {
+		serialNumber = m[UdevSerialShort]
+	} else {
+		serialNumber = m[UdevSerial]
 	}
 	if len(serialNumber) == 0 {
 		return "", "", errors.NewCommonEdgeX(errors.KindServerError,


### PR DESCRIPTION
fix: #25 

Signed-off-by: Felix Ting <felix@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

## Issue Number: #25 


## What is the new behavior?
Use the device property `ID_SERIAL` to id the device if `ID_SERIAL_SHORT` is not found

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information