### PR TITLE
fix: change interval value to go duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ Take the camera Logitech C270 as an example, its Card Name is "C270 HD WEBCAM" a
 > *Note: Card Name and Serial number are used by the device service to uniquely identify a camera, although those cheaply mass-produced cameras may have the same serial number.
 
 #### Enable the Dynamic Discovery function
+Dynamic discovery is disabled by default to save computing resources.
+If you want the device service to run the discovery periodically, enable it and set a desired interval.
+The interval value must be a [Go duration](https://pkg.go.dev/time#ParseDuration).
 
 [Option 1] Enable from the configuration.toml
 ```yaml
@@ -162,18 +165,16 @@ Take the camera Logitech C270 as an example, its Card Name is "C270 HD WEBCAM" a
 ...
     [Device.Discovery]
     Enabled = true
-    Interval = "0"
+    Interval = "1h"
 ```
 
 [Option 2] Enable from the env
 ```shell
 export DEVICE_DISCOVERY_ENABLED=true
-export DEVICE_DISCOVERY_INTERVAL=0
+export DEVICE_DISCOVERY_INTERVAL=1h
 ```
 
-The interval is set to `0` by default, it means that do not run discovery automatically to save computing resources.
 To manually trigger a Dynamic Discovery, use this [device service API](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/device-sdk/2.2.0#/default/post_discovery).
-If you want the device service to run discovery periodically, use a valid [Go duration](https://pkg.go.dev/time#ParseDuration) such as `30s` as the interval.
 
 #### Provision watcher example
 ```shell

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -102,8 +102,8 @@ EnableAsyncReadings = true
 Labels = []
 UseMessageBus = true
   [Device.Discovery]
-  Enabled = true
-  Interval = "0"
+  Enabled = false
+  Interval = "1h"
 
 [Driver]
 RtspServerHostName = "localhost"


### PR DESCRIPTION
Fix for unresolved holding review issue:
- https://github.com/edgexfoundry/device-usb-camera/pull/11#discussion_r859804112

This will result in the same behaviour as before (no discovery by default) but without runtime errors from the invalid interval value.

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information