### PR TITLE
build: Update the version of go4vl to v0.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/edgexfoundry/device-sdk-go/v2 v2.2.0
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0
-	github.com/vladimirvivien/go4vl v0.0.2-0.20211216162907-40b41ba86c5c
+	github.com/vladimirvivien/go4vl v0.0.2
 	github.com/xfrr/goffmpeg v0.0.0-20210624103149-5ca2d3062daf
 )
 

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/vladimirvivien/go4vl v0.0.2-0.20211216162907-40b41ba86c5c h1:49+TOVtKy33akAA7lP+6KAstdOtW8WtqCp7uD0pUk2o=
-github.com/vladimirvivien/go4vl v0.0.2-0.20211216162907-40b41ba86c5c/go.mod h1:FP+/fG/X1DUdbZl9uN+l33vId1QneVn+W80JMc17OL8=
+github.com/vladimirvivien/go4vl v0.0.2 h1:hW+53GiIv8rEfRw2bPE4qhil78CKHVJ7SSKunDEmNp0=
+github.com/vladimirvivien/go4vl v0.0.2/go.mod h1:FP+/fG/X1DUdbZl9uN+l33vId1QneVn+W80JMc17OL8=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xfrr/goffmpeg v0.0.0-20210624103149-5ca2d3062daf h1:oRBFepu2nOiSfYsR0NpxWrWll1bIQKoBrgvzZVQUKlw=

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -73,11 +73,11 @@ func (dev *Device) updateFFmpegOptions(optName, optVal string) {
 	}
 }
 
-func isVideoCaptureSupported(caps *v4l2.Capability) bool {
+func isVideoCaptureSupported(caps v4l2.Capability) bool {
 	return (caps.DeviceCapabilities & v4l2.CapVideoCapture) != 0
 }
 
-func isStreamingSupported(caps *v4l2.Capability) bool {
+func isStreamingSupported(caps v4l2.Capability) bool {
 	return (caps.DeviceCapabilities & v4l2.CapStreaming) != 0
 }
 

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -25,7 +25,7 @@ import (
 	sdkModels "github.com/edgexfoundry/device-sdk-go/v2/pkg/models"
 	"github.com/edgexfoundry/device-sdk-go/v2/pkg/service"
 
-	usbdevice "github.com/vladimirvivien/go4vl/v4l2/device"
+	usbdevice "github.com/vladimirvivien/go4vl/device"
 	"github.com/xfrr/goffmpeg/transcoder"
 )
 
@@ -468,11 +468,7 @@ func (d *Driver) newDevice(name string, protocols map[string]models.ProtocolProp
 	// pre-defined devices may not include serial number information
 	if len(psn) == 0 {
 		device.Protocols[UsbProtocol][SerialNumber] = sn
-		c, err := cameraDevice.GetCapability()
-		if err != nil {
-			return nil, errors.NewCommonEdgeX(errors.KindServerError,
-				fmt.Sprintf("failed to get device capability info,path=%s", fdPath), err)
-		}
+		c := cameraDevice.Capability()
 		device.Protocols[UsbProtocol][CardName] = c.Card
 		if err := d.ds.UpdateDevice(device); err != nil {
 			return nil, errors.NewCommonEdgeX(errors.KindServerError,
@@ -575,11 +571,7 @@ func (d *Driver) isVideoCaptureDevice(path string) bool {
 		return false
 	}
 	defer cameraDevice.Close()
-	c, err := cameraDevice.GetCapability()
-	if err != nil {
-		d.lc.Errorf("failed to get device capability, path=%s, error:%s", path, err.Error())
-		return false
-	}
+	c := cameraDevice.Capability()
 	return isVideoCaptureSupported(c) && isStreamingSupported(c)
 }
 


### PR DESCRIPTION
- Updated the version of go4vl to the latest release v0.0.2 https://github.com/vladimirvivien/go4vl/releases/tag/v0.0.2
- Modified the code a bit to adopt the go4vl API changes

fix: #40 

Signed-off-by: Felix Ting <felix@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
This service currently includes the version v0.0.2-0.20211216162907-40b41ba86c5c of the go4vl dependency in go.mod:


## Issue Number: #40 


## What is the new behavior?
Update to the latest release tag v0.0.2

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why? N/A

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
The go4vl v0.0.2 release introduces a major refactor that simplifies the way the API works. Unfortunately, these changes are not backward compatible with the previous version. Therefore, the code in the driver package need to be adjusted to adopt the go4vl API changes.

## Other information