### PR TITLE
feat: Expose RTSP server's port in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG MAKE="make build"
 ARG ALPINE_PKG_BASE="make git gcc libc-dev zeromq-dev libsodium-dev"
 ARG ALPINE_PKG_EXTRA="v4l-utils-dev v4l-utils v4l-utils-libs linux-headers"
 
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 RUN apk add --no-cache ${ALPINE_PKG_BASE} ${ALPINE_PKG_EXTRA}
 
 WORKDIR /device-usb-camera

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,8 @@ COPY --from=rtsp /rtsp-simple-server.yml /
 COPY --from=rtsp /rtsp-simple-server /
 
 EXPOSE 59983
+# RTSP port of rtsp-simple-server:
+EXPOSE 8554
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD [ "--configProvider=consul.http://edgex-core-consul:8500", "--registry", "--confdir=/res" ]


### PR DESCRIPTION
This is to make it clear that the docker image comes with this server by looking at the Dockerfile.

Related to https://github.com/edgexfoundry/device-usb-camera/issues/48#issuecomment-1185188244

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Neither of the ports for the rtsp-simple-server (see #51) are explicitly exposed in the Dockerfile. RTSP's port is exposed in the reference [docker compose script](https://github.com/edgexfoundry/edgex-compose/blob/ff85f6bff0a3f83f98ac9210ea03f3e4c814f05c/compose-builder/add-device-usb-camera.yml#L24).

## Issue Number:
#48

## What is the new behavior?
RTSP port is explicitly exposed.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information