### PR TITLE
build: Add rtsp-simple-server LICENSE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG BASE=golang:1.17-alpine3.15
 FROM ${BASE} AS builder
 
 ARG MAKE="make build"
-ARG ALPINE_PKG_BASE="make git gcc libc-dev zeromq-dev libsodium-dev"
+ARG ALPINE_PKG_BASE="make git gcc libc-dev zeromq-dev libsodium-dev curl"
 ARG ALPINE_PKG_EXTRA="v4l-utils-dev v4l-utils v4l-utils-libs linux-headers"
 
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
@@ -30,6 +30,8 @@ COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
 
 COPY . .
+
+RUN curl -o LICENSE-rtsp-simple-server https://raw.githubusercontent.com/aler9/rtsp-simple-server/main/LICENSE
 
 RUN ${MAKE}
 
@@ -46,6 +48,7 @@ RUN apk add --update --no-cache zeromq dumb-init ffmpeg udev
 WORKDIR /
 COPY --from=builder /device-usb-camera/cmd /
 COPY --from=builder /device-usb-camera/LICENSE /
+COPY --from=builder /device-usb-camera/LICENSE-rtsp-simple-server /
 COPY --from=builder /device-usb-camera/Attribution.txt /
 COPY --from=builder /device-usb-camera/docker-entrypoint.sh /
 COPY --from=rtsp /rtsp-simple-server.yml /


### PR DESCRIPTION
fix: #53 

Signed-off-by: Felix Ting <felix@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The docker image does not include the [license](https://github.com/aler9/rtsp-simple-server/blob/main/LICENSE) of rtsp-simple-server.

## Issue Number: #53 


## What is the new behavior?
Fetch the LICENSE file from rtsp-simple-server github repo during Docker build.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why? N/A

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing? N/A

## Other information