### PR TITLE
build(docker): Disable unused rtsp-simple-server listeners

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,11 @@ COPY --from=builder /device-usb-camera/docker-entrypoint.sh /
 COPY --from=rtsp /rtsp-simple-server.yml /
 COPY --from=rtsp /rtsp-simple-server /
 
+# disable unused rtsp-simple-server listeners
+RUN sed -i 's/rtmpDisable: no/rtmpDisable: yes/g' rtsp-simple-server.yml
+RUN sed -i 's/hlsDisable: no/hlsDisable: yes/g' rtsp-simple-server.yml
+RUN sed -i 's/protocols: \[udp, multicast, tcp\]/protocols: \[tcp\]/g' rtsp-simple-server.yml
+
 EXPOSE 59983
 # RTSP port of rtsp-simple-server:
 EXPOSE 8554


### PR DESCRIPTION
Signed-off-by: Felix Ting <felix@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The docker image for Device USB Camera pulls in [rtsp-simple-server](https://github.com/aler9/rtsp-simple-server) with its default configurations.

The default configurations results in running the following listeners/servers:
- RTSP (8554)
- RTP (8000) [unused]
- RTCP (8001) [unused] 
- multicastRTP (8002) [unused]
- multicastRTCP (8003) [unused]
- RTMP (1935) [unused]
- HLS (8888) [unused]

## Issue Number: #51 


## What is the new behavior?
Modify rtsp-simple-server configuration during Docker build to disable unused listeners.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information