### PR TITLE
build(snap): Change rtsp-simple-server's config on build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,16 +59,19 @@ parts:
       rtsp-simple-server: bin/rtsp-simple-server
       rtsp-simple-server.yml: config/rtsp-simple-server/config.yml
     build-packages: [curl]
+    build-snaps: [yq/v4/stable]
     override-build: |
       DOC=$SNAPCRAFT_PART_INSTALL/usr/share/doc/rtsp-simple-server
       mkdir -p $DOC
       curl --silent --show-err https://raw.githubusercontent.com/aler9/rtsp-simple-server/main/LICENSE \
         -o $DOC/LICENSE
 
-      sed -i -e 's/rtmpDisable: no/rtmpDisable: yes/g' \
-             -e 's/hlsDisable: no/hlsDisable: yes/g' \
-             -e 's/protocols: \[udp, multicast, tcp\]/protocols: \[tcp\]/g' \
-             -e 's/rtspAddress: :8554/rtspAddress: 127.0.0.1:8554/g' rtsp-simple-server.yml
+      yq -i '
+        .rtmpDisable = "yes" |
+        .hlsDisable = "yes" |
+        .protocols = ["tcp"] |
+        .rtspAddress = "127.0.0.1:8554"
+        ' rtsp-simple-server.yml
       
       snapcraftctl build
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,11 +24,6 @@ plugs:
 apps:
   rtsp-simple-server:
     command: bin/source-env-file.sh $SNAP/bin/rtsp-simple-server $SNAP_DATA/config/rtsp-simple-server/config.yml
-    environment:
-      RTSP_PROTOCOLS: tcp
-      RTSP_RTSPADDRESS: 127.0.0.1:8554
-      RTSP_RTMPDISABLE: true
-      RTSP_HLSDISABLE: true
     daemon: simple
     install-mode: disable
     plugs: [network-bind]
@@ -70,6 +65,11 @@ parts:
       curl --silent --show-err https://raw.githubusercontent.com/aler9/rtsp-simple-server/main/LICENSE \
         -o $DOC/LICENSE
 
+      sed -i -e 's/rtmpDisable: no/rtmpDisable: yes/g' \
+             -e 's/hlsDisable: no/hlsDisable: yes/g' \
+             -e 's/protocols: \[udp, multicast, tcp\]/protocols: \[tcp\]/g' \
+             -e 's/rtspAddress: :8554/rtspAddress: 127.0.0.1:8554/g' rtsp-simple-server.yml
+      
       snapcraftctl build
 
   device-usb-camera:


### PR DESCRIPTION
Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?

Validate RTSP server is being restricted to run only an RTSP/TCP listener that binds to the loopback interface:
```
$ snap start edgex-device-usb-camera.rtsp-simple-server 
$ snap logs edgex-device-usb-camera.rtsp-simple-server
...
[RTSP] listener opened on 127.0.0.1:8554 (TCP)

# Add UDP to protocols
$ snap set edgex-device-usb-camera apps.rtsp-simple-server.config.rtsp-protocols="tcp,udp"
$ snap start edgex-device-usb-camera.rtsp-simple-server 

# Verify that the UDP listener are started
$ snap logs edgex-device-usb-camera.rtsp-simple-server
...
[RTSP] listener opened on 127.0.0.1:8554 (TCP), :8000 (UDP/RTP), :8001 (UDP/RTCP)
```

## Other information