### PR TITLE
fix: error forwarding in startStreaming

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -640,15 +640,17 @@ func (d *Driver) startStreaming(device *Device) errors.EdgeX {
 		select {
 		case err := <-errChan:
 			device.StopStreaming(err)
-			startErrs <- errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("the video streaming process for device %s has stopped, error: %s", device.name, err), err)
 			d.lc.Debugf("the video streaming process for device %s has stopped", device.name)
+			startErrs <- errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("the video streaming process for device %s has stopped, error: %s", device.name, err), err)
 			d.wg.Done()
 			return
 		case <-device.ctx.Done():
 			if err := device.transcoder.Stop(); err != nil {
 				d.lc.Errorf("failed to stop video streaming for device %s, error: %s", device.name, err)
+				startErrs <- errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to stop video streaming for device %s, error: %s", device.name, err), err)
+				d.wg.Done()
+				return
 			}
-			startErrs <- errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to stop video streaming for device %s, error: %s", device.name, err), err)
 			d.lc.Debugf("the video streaming process for device %s has stopped", device.name)
 			d.wg.Done()
 			return


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->
Closes #23 
<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Make sure that the service is not streaming. Then, execute the startStreaming command, making sure that it should create an error (invalid input, etc). The rest response should be an error code with a description of the error.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->