### PR TITLE
feat(snap): Copy provision watcher files in snapcraft

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -107,9 +107,7 @@ parts:
 
       RES=$SNAPCRAFT_PART_INSTALL/config/device-usb-camera/res/
       mkdir -p $RES
-      cp    cmd/res/configuration.toml $RES
-      cp -r cmd/res/devices $RES
-      cp -r cmd/res/profiles $RES
+      cp -r cmd/res/* $RES
       
       DOC=$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-usb-camera
       mkdir -p $DOC


### PR DESCRIPTION
Provision watcher has been added and auto-enabled through PR https://github.com/edgexfoundry/device-usb-camera/pull/69. provision_watchers directory was missing from the Snap package, so this PR copies the entire `cmd/res` directory, which also includes provision_watchers directory, into Snap.

The absence of this file does not affect normal functions, but it does prevent the auto-discovery function from working properly.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?): https://github.com/edgexfoundry/edgex-docs/pull/964
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Install snap built from this PR
2. Validate that the error of missing provision_watchers no longer appears in logs

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->