### PR TITLE
fix(snap): Set snap-specific provision watchers directory

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,6 +42,7 @@ apps:
       REGISTRY_ARG: "--registry"
       DEVICE_PROFILESDIR: "$SNAP_DATA/config/device-usb-camera/res/profiles"
       DEVICE_DEVICESDIR: "$SNAP_DATA/config/device-usb-camera/res/devices"
+      DEVICE_PROVISIONWATCHERSDIR: "$SNAP_DATA/config/device-usb-camera/res/provisionwatchers"
       SECRETSTORE_TOKENFILE: $SNAP_DATA/device-usb-camera/secrets-token.json
       # Add shared library object file to path for ffprobe/ffmpeg
       LD_LIB: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET


### PR DESCRIPTION
This PR overrides the variable `Device.ProvisionWatchersDir` in snapcraft.yaml to solve the following 'fail to find the directory path of provision watchers' error which was introduced since https://github.com/edgexfoundry/device-usb-camera/pull/165:
```
edgex-device-usb-camera.device-usb-camera[237888]: level=INFO ts=2023-03-08T18:40:48.677022263Z app=device-usb-camera source=profiles.go:88 msg="Profile USB-Camera-General exists, using the existing one"
edgex-device-usb-camera.device-usb-camera[237888]: level=INFO ts=2023-03-08T18:40:48.677084239Z app=device-usb-camera source=devices.go:49 msg="Loading pre-defined devices from /var/snap/edgex-device-usb-camera/368/config/device-usb-camera/res/devices"
edgex-device-usb-camera.device-usb-camera[237888]: level=ERROR ts=2023-03-08T18:40:48.677113995Z app=device-usb-camera source=init.go:84 msg="Failed to create the pre-defined provision watchers: failed to read directory -> open /var/snap/edgex-device-usb-camera/368/res/provisionwatchers: no such file or directory"
```

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->