### PR TITLE
fix: device-sdk levski patch stable tag added

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/device-usb-camera
 go 1.18
 
 require (
-	github.com/edgexfoundry/device-sdk-go/v2 v2.3.1-dev.3
+	github.com/edgexfoundry/device-sdk-go/v2 v2.3.1
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.3.0
 	github.com/stretchr/testify v1.8.0
 	github.com/vladimirvivien/go4vl v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.1 h1:tUSpviiL5G3P9SZZJPC4ZULZJsxQKXxfENpMvdbAXAI=
 github.com/eclipse/paho.mqtt.golang v1.4.1/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/device-sdk-go/v2 v2.3.1-dev.3 h1:wmxD96TEUmIivVe+5rF/tXXBdgXKCNdYzvdR/p8sjO8=
-github.com/edgexfoundry/device-sdk-go/v2 v2.3.1-dev.3/go.mod h1:QbA/sWfx6LoyWn/K992LdcB7tnktlPNHK3PtCORlyxI=
+github.com/edgexfoundry/device-sdk-go/v2 v2.3.1 h1:ivgyIS4aVdNmVNZIWfgNY48mD6XY6mJHLhhL3kf+1I8=
+github.com/edgexfoundry/device-sdk-go/v2 v2.3.1/go.mod h1:QbA/sWfx6LoyWn/K992LdcB7tnktlPNHK3PtCORlyxI=
 github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0 h1:NCOc5bOz6oX+KuOcv0Rt6BTSDShbg4VmCapXO19IoCM=
 github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0/go.mod h1:jWZjsy0BaO6+S+Tq111mcrkGKpg6bhTyqngyYcl+70E=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.3.0 h1:VeK7VBiNc/RIR7HXC0ya3fWCmcFQzrSLITPYn87cQsA=


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
make test
make docker
/compose-builder$ git checkout levski
/compose-builder$ make pull
/compose-builder$ make gen no-secty ds-usb-camera (this generates docker-compose.yml with levski based edgex images)
Replace usb camera service docker image in docker-compose.yml with your latest image created using make docker from the previous step (0.0.0-dev)
/compose-builder$ make up
Usb camera devices should be registered in Edgex
Sending any valid command to the usb device should be successful
Verify start streaming working
Stop the usb camera docker service
un-plug camera and plug back in to another usb port or some other way to trigger a different /dev/videoXX path
Start the usb camera docker service
Verify the device has been updated in metadata with new video path
Re-sending commands to the device as done previously should be successful
Re-verify start streaming still works

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->