### PR TITLE
fix: return ffmpeg error logs to caller, and fix StreamingStatus

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
 linters:
-  disable:
+  disable: []
   enable:
     - gosec

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -7,8 +7,9 @@
 package driver
 
 import (
-	"context"
 	"fmt"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
 	"reflect"
 	"regexp"
 	"strings"
@@ -32,13 +33,12 @@ var (
 )
 
 type Device struct {
+	lc                          logger.LoggingClient
 	name                        string
 	path                        string
 	serialNumber                string
 	rtspUri                     string
 	transcoder                  *transcoder.Transcoder
-	ctx                         context.Context
-	cancelFunc                  context.CancelFunc
 	autoStreaming               bool
 	mutex                       sync.Mutex
 	streamingStatus             streamingStatus
@@ -57,30 +57,34 @@ type streamingStatus struct {
 	OutputVideoQuality string
 }
 
-func (dev *Device) StartStreaming(ctx context.Context, cancel context.CancelFunc) (<-chan error, error) {
+func (dev *Device) StartStreaming() (<-chan error, error) {
 	dev.mutex.Lock()
-	defer dev.mutex.Unlock()
-	if dev.streamingStatus.IsStreaming {
+	isStreaming := dev.streamingStatus.IsStreaming
+	dev.mutex.Unlock()
+	if isStreaming {
 		return nil, fmt.Errorf("video streaming is already in progress")
 	}
-	dev.ctx = ctx
-	dev.cancelFunc = cancel
-	errChan := dev.transcoder.Run(false)
-	dev.streamingStatus.IsStreaming = true
+
+	dev.lc.Infof("Attempting to start streaming device %s", dev.name)
+	errChan, err := dev.runTranscoderWithOutput()
+	if err != nil {
+		wrappedErr := errors.NewCommonEdgeX(errors.KindServerError, "failed running ffmpeg transcoder for device "+dev.name, err)
+		return nil, wrappedErr
+	}
 	return errChan, nil
 }
 
-func (dev *Device) StopStreaming(err error) {
+func (dev *Device) StopStreaming() {
 	dev.mutex.Lock()
 	defer dev.mutex.Unlock()
-	if err != nil {
-		dev.streamingStatus.Error = err.Error()
-	} else {
-		dev.streamingStatus.Error = ""
+	if !dev.streamingStatus.IsStreaming {
+		return
 	}
-	if dev.streamingStatus.IsStreaming {
-		dev.cancelFunc()
-		dev.streamingStatus.IsStreaming = false
+
+	dev.lc.Debugf("Stopping transcoder for device %s", dev.name)
+	if err := dev.transcoder.Stop(); err != nil {
+		dev.lc.Errorf("Failed to stop video streaming transcoder for device %s, error: %s", dev.name, err)
+		return
 	}
 }
 

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -57,21 +57,21 @@ type streamingStatus struct {
 	OutputVideoQuality string
 }
 
-func (dev *Device) StartStreaming() (<-chan error, error) {
+func (dev *Device) StartStreaming() (<-chan string, <-chan error, error) {
 	dev.mutex.Lock()
 	isStreaming := dev.streamingStatus.IsStreaming
 	dev.mutex.Unlock()
 	if isStreaming {
-		return nil, fmt.Errorf("video streaming is already in progress")
+		return nil, nil, fmt.Errorf("video streaming is already in progress")
 	}
 
 	dev.lc.Infof("Attempting to start streaming device %s", dev.name)
-	errChan, err := dev.runTranscoderWithOutput()
+	progressChan, errChan, err := dev.runTranscoderWithOutput()
 	if err != nil {
 		wrappedErr := errors.NewCommonEdgeX(errors.KindServerError, "failed running ffmpeg transcoder for device "+dev.name, err)
-		return nil, wrappedErr
+		return nil, nil, wrappedErr
 	}
-	return errChan, nil
+	return progressChan, errChan, nil
 }
 
 func (dev *Device) StopStreaming() {

--- a/internal/driver/helper.go
+++ b/internal/driver/helper.go
@@ -18,7 +18,7 @@ const (
 )
 
 var (
-	userPassRegex = regexp.MustCompile("//(\\S+):(\\S+)@")
+	userPassRegex = regexp.MustCompile(`//(\S+):(\S+)@`)
 )
 
 type EdgeXErrorWrapper struct{}

--- a/internal/driver/helper.go
+++ b/internal/driver/helper.go
@@ -8,12 +8,26 @@ package driver
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
+)
+
+const (
+	redactedStr = "//<redacted>@"
+)
+
+var (
+	userPassRegex = regexp.MustCompile("//(\\S+):(\\S+)@")
 )
 
 type EdgeXErrorWrapper struct{}
 
 func (e EdgeXErrorWrapper) CommandError(command string, err error) errors.EdgeX {
 	return errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to execute %s command", command), err)
+}
+
+// redact removes all instances of basic auth (ie. rtsp://username:password@server) from a url
+func redact(val string) string {
+	return userPassRegex.ReplaceAllString(val, redactedStr)
 }

--- a/internal/driver/transcoder.go
+++ b/internal/driver/transcoder.go
@@ -1,0 +1,178 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package driver
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
+	"os/exec"
+	"strings"
+)
+
+const (
+	maxStderrLines = 25
+	ffmpegLogLevel = "info"
+)
+
+// runTranscoderWithOutput is based on transcoder.Transcoder.Run(), but tweaks a few things, and adds some
+// quality of life improvements for the end user. It starts the transcoding process while also logging the ffmpeg
+// output (from StdErr). StdErr text is also returned via the done error channel, so that it can be returned
+// to the caller of a REST API. If an error occurs starting the process, it is returned immediately, and not
+// via the error channel.
+func (dev *Device) runTranscoderWithOutput() (<-chan error, error) {
+	dev.mutex.Lock()
+	defer dev.mutex.Unlock()
+
+	t := dev.transcoder
+
+	// generate the ffmpeg command line options, and prepend with some pre-defined options
+	// -loglevel level+<ffmpegLogLevel>: will set the log level to ffmpegLogLevel and prefix output with the log level (for parsing)
+	command := append([]string{"-loglevel", "level+" + ffmpegLogLevel}, t.GetCommand()...)
+	if dev.lc.LogLevel() != models.TraceLog {
+		// disable progress output if trace logging is not enabled
+		command = append([]string{"-nostats"}, command...)
+	}
+	// -rtsp_transport tcp: force the rtsp transport to use tcp
+	// these args must be put in the output section and not the first args, so just inject them right before the last
+	// arg which is the rtsp url.
+	command = append(command[0:len(command)-1], "-rtsp_transport", "tcp", command[len(command)-1])
+	proc := exec.Command(t.FFmpegExec(), command...)
+
+	// Set the stdinPipe in case we need to stop the transcoding
+	stdinPipe, err := proc.StdinPipe()
+	if err != nil {
+		dev.lc.Errorf("Ffmpeg Stdin not available: %s", err.Error())
+	}
+
+	var stdErrLines []string
+	stdErrPipe, err := proc.StderrPipe()
+	if err != nil {
+		dev.lc.Errorf("Ffmpeg StderrPipe not available: %s. Unable to track output from process.", err.Error())
+	} else {
+		output := make(chan string, 10)
+		// use a scanner to read the output of the pipe and send it to output channel
+		go func() {
+			defer close(output)
+			scanner := bufio.NewScanner(stdErrPipe)
+			scanner.Split(scanFFmpegLines)
+			scanner.Buffer(make([]byte, 2), bufio.MaxScanTokenSize)
+
+			for scanner.Scan() {
+				// Scan the next line, redact it, and send it to output channel.
+				output <- redact(scanner.Text())
+			}
+			dev.lc.Debugf("Output scanner complete for transcoder for device %s", dev.name)
+		}()
+
+		// keep track of stdErr text, so it can be returned to the caller via done channel
+		go func() {
+			for line := range output {
+				// cap the size so that way the memory usage does not grow on commands with lots of output
+				if len(stdErrLines) >= maxStderrLines {
+					continue
+				}
+
+				line = strings.Trim(line, " ")
+				if len(line) == 0 {
+					continue // skip blank lines
+				}
+
+				// log the line at specific level depending on the content
+				if strings.Contains(line, "[error]") || strings.Contains(line, "[fatal]") {
+					stdErrLines = append(stdErrLines, line)
+					dev.lc.Errorf("%s transcoder: %s", dev.name, line)
+				} else if strings.Contains(line, "[warning]") {
+					stdErrLines = append(stdErrLines, line)
+					dev.lc.Warnf("%s transcoder: %s", dev.name, line)
+				} else {
+					// log everything else as debug, as ffmpeg info messages are just debug data to us
+					dev.lc.Debugf("%s transcoder: %s", dev.name, line)
+				}
+			}
+			dev.lc.Debugf("Done processing output for transcoder for device %s", dev.name)
+		}()
+	}
+
+	// attempt to start the process
+	if err = proc.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start FFMPEG transcoding for device %s (%s) with %s, message %s",
+			dev.name, redact(strings.Join(command, " ")), err, strings.Join(stdErrLines, "\n"))
+	}
+	// only set the transcoder's process if we are successful in starting it
+	t.SetProcess(proc)
+	t.SetProcessStdinPipe(stdinPipe)
+	dev.lc.Debugf("Set IsStreaming=true for device %s", dev.name)
+	dev.streamingStatus.IsStreaming = true
+	dev.streamingStatus.Error = ""
+
+	dev.lc.Debugf("FFmpeg transcoder process for device %s has started with pid %d", dev.name, proc.Process.Pid)
+
+	// in the background we will wait for the process to complete and return any errors over the done channel
+	done := make(chan error)
+	go func() {
+		defer close(done)
+
+		// wait until the process has exited
+		err = proc.Wait()
+		dev.lc.Debugf("FFmpeg process with pid %d for device %s exited with code %d. User time: %v, System time: %v",
+			proc.Process.Pid, dev.name, proc.ProcessState.ExitCode(), proc.ProcessState.UserTime(), proc.ProcessState.UserTime())
+
+		dev.mutex.Lock()
+		dev.lc.Debugf("Set IsStreaming=false for device %s", dev.name)
+		dev.streamingStatus.IsStreaming = false
+
+		// if ffmpeg returned an error, add more details surrounding it
+		if err != nil {
+			err = fmt.Errorf("failed finish FFMPEG transcoding for device %s (%s) with %s message %s",
+				dev.name, redact(strings.Join(command, " ")), err.Error(), strings.Join(stdErrLines, "\n"))
+			dev.streamingStatus.Error = err.Error()
+		} else {
+			dev.streamingStatus.Error = ""
+		}
+		t.SetProcess(nil)
+		t.SetProcessStdinPipe(nil)
+		dev.mutex.Unlock()
+		done <- err
+	}()
+
+	return done, nil
+}
+
+// scanFFmpegLines is based on bufio.ScanLines, however it will return a line as soon as
+// it reaches a \r even if it is not followed by a \n. The reason for this is that ffmpeg
+// sometimes uses \r as a way to replace the previous line, such as when progress is enabled.
+// In those cases, the default bufio.ScanLines will miss those messages.
+func scanFFmpegLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		// No more data. Return.
+		return 0, nil, nil
+	}
+
+	if i := bytes.IndexByte(data, '\r'); i == 0 {
+		return 1, nil, nil // Skip blank line.
+	} else if i > 0 {
+		// We have a cr terminated line
+		return i + 1, data[0:i], nil
+	}
+
+	if i := bytes.IndexByte(data, '\n'); i == 0 {
+		return 1, nil, nil // Skip blank line.
+	} else if i > 0 {
+		// We have a newline terminated line.
+		return i + 1, data[0:i], nil
+	}
+
+	// If we are at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+
+	// Request more data.
+	return 0, nil, nil
+}

--- a/internal/driver/transcoder.go
+++ b/internal/driver/transcoder.go
@@ -42,8 +42,8 @@ func (dev *Device) runTranscoderWithOutput() (<-chan error, error) {
 	// these args must be put in the output section and not the first args, so just inject them right before the last
 	// arg which is the rtsp url.
 	command = append(command[0:len(command)-1], "-rtsp_transport", "tcp", command[len(command)-1])
-	// todo: evaluate shell injection risks. if safe, use: // nolint: gosec
-	proc := exec.Command(t.FFmpegExec(), command...)
+	ffmpegBin := t.FFmpegExec()
+	proc := exec.Command(ffmpegBin, command...)
 
 	// Set the stdinPipe in case we need to stop the transcoding
 	stdinPipe, err := proc.StdinPipe()

--- a/internal/driver/transcoder.go
+++ b/internal/driver/transcoder.go
@@ -42,6 +42,7 @@ func (dev *Device) runTranscoderWithOutput() (<-chan error, error) {
 	// these args must be put in the output section and not the first args, so just inject them right before the last
 	// arg which is the rtsp url.
 	command = append(command[0:len(command)-1], "-rtsp_transport", "tcp", command[len(command)-1])
+	// todo: evaluate shell injection risks. if safe, use: // nolint: gosec
 	proc := exec.Command(t.FFmpegExec(), command...)
 
 	// Set the stdinPipe in case we need to stop the transcoding


### PR DESCRIPTION
FFmpeg transcoder logic has been implemented within the driver code now, so that way we have more control over it. This allows us to keep track of the process output and log it to the console as well as return it to the caller of StartStreaming. Because we have more precise control over the process, we can better sync the StreamingStatus to whether or not the ffmpeg process is running.

The handling of publishing StreamingStatus to the message bus has been optimized to send better based on when it actually changes, and not send when the user calls StopStreaming when already stopped, or StartStreaming when already started.

Logic has also been added to redact the rtsp credentials from the log file and API responses to avoid exposing secrets to the caller.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

- checkout and build this PR
- run edgex in secure or non secure mode using the image built from this pr
  - update `add-device-usb-camera.yaml`
  - run `make run ds-usb-camera`
- wait for your camera to be auto-detected, and get the device name
- execute StartStreaming, and expect a 500 error with a log message that contains messages related to 401 authentication error
- execute StreamingStatus and verify isstreaming=false and error is the same (or a subset) of the api call result
- post your rtspauth credentials to `/api/v3/secrets`  using the guide from edgex-docs (see **step 4** [here](https://docs.edgexfoundry.org/3.0/microservices/device/supported/device-usb-camera/walkthrough/deployment/#verify-service-device-profiles-and-device))
- execute StartStreaming with **valid** inputs and expect it to return a 200 OK, taking about 1 second as before
- view the stream using mplayer or ffplay (see [here](https://docs.edgexfoundry.org/3.0/microservices/device/supported/device-usb-camera/walkthrough/general-usage/))
- execute StreamingStatus and see that there is no error, and isstreaming=true
- execute StartStreaming and expect an error already running
- execute StreamingStatus and see that there is no error, and isstreaming=true
- execute StopStreaming and expect 200 OK
- execute StreamingStatus and see that there is no error, and isstreaming=false
- execute StopStreaming and expect 200 OK
- execute StreamingStatus and see that there is no error, and isstreaming=false
- execute StartStreaming with **invalid** inputs and expect it to return a 500 error, with details about the error such as `mpeg456` not being valid
- execute StreamingStatus and verify isstreaming=false and error is the same (or a subset) of the api call result
- execute StopStreaming and expect 200 OK
- execute StreamingStatus and nothing has changed


additional things to validate:
- start streaming and then stop the device service while still streaming. make sure the camera is no longer active. start the service back up and ensure it starts fine and u can start streaming the same camera again no problems.
- try and start streaming invalid input, and then make sure stream with valid afterwards still works
- try and start streaming with invalid input and then stop the device service. start the service back up and ensure it starts fine and u can start streaming the same camera again no problems.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->

Fixes #253 
Implements a proper fix for #23 