### PR TITLE
feat: SetFps v4l2 + ffmpeg command

### DIFF
--- a/cmd/res/profiles/general.usb.camera.yaml
+++ b/cmd/res/profiles/general.usb.camera.yaml
@@ -90,7 +90,7 @@ deviceResources:
   - name: "SetFramerate"
     description: "Set the stream Framerate rate"
     attributes: 
-      { command: "VIDEO_SET_FPS"}
+      { command: "VIDEO_SET_FRAMERATE"}
     properties:
       valueType: "Object"
       readWrite: "W"

--- a/cmd/res/profiles/general.usb.camera.yaml
+++ b/cmd/res/profiles/general.usb.camera.yaml
@@ -44,6 +44,13 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "R"
+  - name: "FpsFormats"
+    description: "Enumerate supported fps settings, see https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enum-frameintervals.html"
+    attributes:
+      { command: "METADATA_FPS_FORMATS" }
+    properties:
+      valueType: "Object"
+      readWrite: "R"
   - name: "DataFormat"
     description: "Get data format, see https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enuminput.html."
     attributes:
@@ -80,7 +87,7 @@ deviceResources:
       valueType: "Bool"
       readWrite: "W"
       defaultValue: "false"
-  - name: "SetFPS"
+  - name: "SetFps"
     description: "Set the stream FPS rate"
     attributes: 
       { command: "VIDEO_SET_FPS"}

--- a/cmd/res/profiles/general.usb.camera.yaml
+++ b/cmd/res/profiles/general.usb.camera.yaml
@@ -80,6 +80,13 @@ deviceResources:
       valueType: "Bool"
       readWrite: "W"
       defaultValue: "false"
+  - name: "SetFPS"
+    description: "Set the stream FPS rate"
+    attributes: 
+      { command: "VIDEO_SET_FPS"}
+    properties:
+      valueType: "Object"
+      readWrite: "W"
   - name: "StreamURI"
     description: "Get video-streaming URI."
     attributes:

--- a/cmd/res/profiles/general.usb.camera.yaml
+++ b/cmd/res/profiles/general.usb.camera.yaml
@@ -94,6 +94,13 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "W"
+  - name: "GetFramerate"
+    description: "Get the stream Framerate rate"
+    attributes: 
+      { command: "VIDEO_GET_FRAMERATE"}
+    properties:
+      valueType: "Object"
+      readWrite: "R"
   - name: "StreamURI"
     description: "Get video-streaming URI."
     attributes:

--- a/cmd/res/profiles/general.usb.camera.yaml
+++ b/cmd/res/profiles/general.usb.camera.yaml
@@ -44,8 +44,8 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "R"
-  - name: "FramerateFormats"
-    description: "Enumerate supported framerate settings, see https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enum-frameintervals.html"
+  - name: "FrameRateFormats"
+    description: "Enumerate supported frame rate settings, see https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enum-frameintervals.html"
     attributes:
       { command: "METADATA_FRAMERATE_FORMATS" }
     properties:
@@ -87,15 +87,15 @@ deviceResources:
       valueType: "Bool"
       readWrite: "W"
       defaultValue: "false"
-  - name: "SetFramerate"
-    description: "Set the stream Framerate rate"
+  - name: "SetFrameRate"
+    description: "Set the stream frame rate rate"
     attributes: 
       { command: "VIDEO_SET_FRAMERATE"}
     properties:
       valueType: "Object"
       readWrite: "W"
-  - name: "GetFramerate"
-    description: "Get the stream Framerate rate"
+  - name: "GetFrameRate"
+    description: "Get the stream frame rate rate"
     attributes: 
       { command: "VIDEO_GET_FRAMERATE"}
     properties:

--- a/cmd/res/profiles/general.usb.camera.yaml
+++ b/cmd/res/profiles/general.usb.camera.yaml
@@ -88,14 +88,14 @@ deviceResources:
       readWrite: "W"
       defaultValue: "false"
   - name: "SetFrameRate"
-    description: "Set the stream frame rate rate"
+    description: "Set the stream frame rate"
     attributes: 
       { command: "VIDEO_SET_FRAMERATE"}
     properties:
       valueType: "Object"
       readWrite: "W"
   - name: "GetFrameRate"
-    description: "Get the stream frame rate rate"
+    description: "Get the stream frame rate"
     attributes: 
       { command: "VIDEO_GET_FRAMERATE"}
     properties:

--- a/cmd/res/profiles/general.usb.camera.yaml
+++ b/cmd/res/profiles/general.usb.camera.yaml
@@ -47,7 +47,7 @@ deviceResources:
   - name: "FramerateFormats"
     description: "Enumerate supported framerate settings, see https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enum-frameintervals.html"
     attributes:
-      { command: "METADATA_FPS_FORMATS" }
+      { command: "METADATA_FRAMERATE_FORMATS" }
     properties:
       valueType: "Object"
       readWrite: "R"

--- a/cmd/res/profiles/general.usb.camera.yaml
+++ b/cmd/res/profiles/general.usb.camera.yaml
@@ -44,8 +44,8 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "R"
-  - name: "FpsFormats"
-    description: "Enumerate supported fps settings, see https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enum-frameintervals.html"
+  - name: "FramerateFormats"
+    description: "Enumerate supported framerate settings, see https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enum-frameintervals.html"
     attributes:
       { command: "METADATA_FPS_FORMATS" }
     properties:
@@ -87,8 +87,8 @@ deviceResources:
       valueType: "Bool"
       readWrite: "W"
       defaultValue: "false"
-  - name: "SetFps"
-    description: "Set the stream FPS rate"
+  - name: "SetFramerate"
+    description: "Set the stream Framerate rate"
     attributes: 
       { command: "VIDEO_SET_FPS"}
     properties:

--- a/cmd/res/profiles/general.usb.camera.yaml
+++ b/cmd/res/profiles/general.usb.camera.yaml
@@ -88,7 +88,7 @@ deviceResources:
       readWrite: "W"
       defaultValue: "false"
   - name: "FrameRate"
-    description: "Set the stream frame rate"
+    description: "Set and get the stream frame rate"
     attributes: 
         getFunction: "VIDEO_GET_FRAMERATE"
         setFunction: "VIDEO_SET_FRAMERATE"

--- a/cmd/res/profiles/general.usb.camera.yaml
+++ b/cmd/res/profiles/general.usb.camera.yaml
@@ -12,7 +12,7 @@ deviceResources:
       Camera information including driver name, device name, bus info, and capabilities.
       See https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/vidioc-querycap.html.
     attributes:
-      { command: "METADATA_DEVICE_CAPABILITY" }
+      { getFunction: "METADATA_DEVICE_CAPABILITY" }
     properties:
       valueType: "Object"
       readWrite: "R"
@@ -21,7 +21,7 @@ deviceResources:
       Query or select the current video input.
       See https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-g-input.html.
     attributes:
-      { command: "METADATA_CURRENT_VIDEO_INPUT" }
+      { getFunction: "METADATA_CURRENT_VIDEO_INPUT" }
     properties:
       valueType: "Int8"
       readWrite: "R"
@@ -33,90 +33,84 @@ deviceResources:
       0x00000002 - No Signal
       0x00000003 - No Color
     attributes:
-      { command: "METADATA_CAMERA_STATUS" }
+      { getFunction: "METADATA_CAMERA_STATUS" }
     properties:
       valueType: "Uint32"
       readWrite: "R"
   - name: "ImageFormats"
     description: "Enumerate image formats, see https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enum-fmt.html."
     attributes:
-      { command: "METADATA_IMAGE_FORMATS" }
+      { getFunction: "METADATA_IMAGE_FORMATS" }
     properties:
       valueType: "Object"
       readWrite: "R"
   - name: "FrameRateFormats"
     description: "Enumerate supported frame rate settings, see https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enum-frameintervals.html"
     attributes:
-      { command: "METADATA_FRAMERATE_FORMATS" }
+      { getFunction: "METADATA_FRAMERATE_FORMATS" }
     properties:
       valueType: "Object"
       readWrite: "R"
   - name: "DataFormat"
     description: "Get data format, see https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enuminput.html."
     attributes:
-      { command: "METADATA_DATA_FORMAT" }
+      { getFunction: "METADATA_DATA_FORMAT" }
     properties:
       valueType: "Object"
       readWrite: "R"
   - name: "CropCapability"
     description: "Information about the video cropping and scaling abilities, see https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/vidioc-cropcap.html."
     attributes:
-      { command: "METADATA_CROPPING_ABILITY" }
+      { getFunction: "METADATA_CROPPING_ABILITY" }
     properties:
       valueType: "Object"
       readWrite: "R"
   - name: "StreamingParam"
     description: "Get streaming parameters, see https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-g-parm.html."
     attributes:
-      { command: "METADATA_STREAMING_PARAMETERS" }
+      { getFunction: "METADATA_STREAMING_PARAMETERS" }
     properties:
       valueType: "Object"
       readWrite: "R"
   - name: "StartStreaming"
     description: "Start streaming process."
     attributes:
-      { command: "VIDEO_START_STREAMING" }
+      { setFunction: "VIDEO_START_STREAMING" }
     properties:
       valueType: "Object"
       readWrite: "W"
   - name: "StopStreaming"
     description: "Stop streaming process."
     attributes:
-      { command: "VIDEO_STOP_STREAMING" }
+      { setFunction: "VIDEO_STOP_STREAMING" }
     properties:
       valueType: "Bool"
       readWrite: "W"
       defaultValue: "false"
-  - name: "SetFrameRate"
+  - name: "FrameRate"
     description: "Set the stream frame rate"
     attributes: 
-      { command: "VIDEO_SET_FRAMERATE"}
+        getFunction: "VIDEO_GET_FRAMERATE"
+        setFunction: "VIDEO_SET_FRAMERATE"
     properties:
       valueType: "Object"
-      readWrite: "W"
-  - name: "GetFrameRate"
-    description: "Get the stream frame rate"
-    attributes: 
-      { command: "VIDEO_GET_FRAMERATE"}
-    properties:
-      valueType: "Object"
-      readWrite: "R"
+      readWrite: "RW"
   - name: "StreamURI"
     description: "Get video-streaming URI."
     attributes:
-      { command: "VIDEO_STREAM_URI" }
+      { getFunction: "VIDEO_STREAM_URI" }
     properties:
       valueType: "String"
       readWrite: "R"
   - name: "StreamingStatus"
     description: "Get streaming status, including FFmpeg options"
     attributes:
-      { command: "VIDEO_STREAMING_STATUS" }
+      { getFunction: "VIDEO_STREAMING_STATUS" }
     properties:
       valueType: "Object"
       readWrite: "RW"
 
-deviceCommands:
+devicegetFunctions:
   - name: "GetCameraMetaData"
     readWrite: "R"
     isHidden: false

--- a/cmd/res/profiles/general.usb.camera.yaml
+++ b/cmd/res/profiles/general.usb.camera.yaml
@@ -110,7 +110,7 @@ deviceResources:
       valueType: "Object"
       readWrite: "RW"
 
-devicegetFunctions:
+deviceCommands:
   - name: "GetCameraMetaData"
     readWrite: "R"
     isHidden: false

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -815,7 +815,7 @@
 			"response": []
 		},
 		{
-			"name": "Start streaming with nvalid input and output",
+			"name": "Start streaming with invalid input and output",
 			"event": [
 				{
 					"listen": "test",

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "75aba832-57a8-4306-b0ce-c4cb2d4ba785",
+		"_postman_id": "57da9c2a-e1d1-4c55-9ee4-304b0f4a8c8d",
 		"name": "USB-Camera-Collection",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "19151794"
 	},
 	"item": [
 		{
@@ -252,6 +253,55 @@
 			"response": []
 		},
 		{
+			"name": "Get supported fps formats",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"  pm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/FpsFormats",
+					"protocol": "http",
+					"host": [
+						"{{command_host}}"
+					],
+					"port": "{{command_port}}",
+					"path": [
+						"api",
+						"v3",
+						"device",
+						"name",
+						"{{camera_name}}",
+						"FpsFormats"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Get video crop capability",
 			"event": [
 				{
@@ -493,6 +543,53 @@
 						"StreamingStatus"
 					]
 				}
+			},
+			"response": []
+		},
+		{
+			"name": "Set FPS",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"  pm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "PUT",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"SetFps\":\n{\"FpsValue\":\"5\"}\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/SetFps",
+					"protocol": "http",
+					"host": [
+						"{{command_host}}"
+					],
+					"port": "{{command_port}}",
+					"path": [
+						"api",
+						"v3",
+						"device",
+						"name",
+						"{{camera_name}}",
+						"SetFps"
+					]
+				},
+				"description": "Test steps:\n1) Execute get data format api to get the current fps values for current stream resolution \n2) Execute Get fps formats to see possible values of fps for each given resolution \n3) Execute set fps api with valid input"
 			},
 			"response": []
 		},

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -632,7 +632,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\"FrameRate\": {\n        \"FpsValueDenominator\":\"1\",\n        \"FpsValueNumerator\":\"30\"\n    }\n}",
+					"raw": "{\n\"FrameRate\": {\n        \"FrameRateValueDenominator\":\"1\",\n        \"FrameRateValueNumerator\":\"30\"\n    }\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -246,6 +246,12 @@
 						"name",
 						"{{camera_name}}",
 						"DataFormat"
+					],
+                    "query": [
+						{
+							"key": "PathIndex",
+							"value": "0"
+						}
 					]
 				}
 			},

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -2,8 +2,7 @@
 	"info": {
 		"_postman_id": "0b15519a-2feb-4028-bdef-c91b7cb8b16c",
 		"name": "USB-Camera-Collection",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "19151794"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -632,7 +632,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\"FrameRate\": {\n        \"FpsValueDenominator\":\"30\",\n        \"FpsValueNumerator\":\"1\"\n    }\n}",
+					"raw": "{\n\"FrameRate\": {\n        \"FpsValueDenominator\":\"1\",\n        \"FpsValueNumerator\":\"30\"\n    }\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -283,7 +283,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/FpsFormats",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/FramerateFormats",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -295,7 +295,7 @@
 						"device",
 						"name",
 						"{{camera_name}}",
-						"FpsFormats"
+						"FramerateFormats"
 					]
 				}
 			},
@@ -566,7 +566,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\"SetFps\":\n{\"FpsValueDenominator\":\"10\",\n{\"FpsValueNumerator\":\"1\"}\n}",
+					"raw": "{\"SetFramerate\":\n{\"FpsValueDenominator\":\"10\",\n{\"FpsValueNumerator\":\"1\"}\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -574,7 +574,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/SetFps",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/SetFramerate",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -586,7 +586,7 @@
 						"device",
 						"name",
 						"{{camera_name}}",
-						"SetFps"
+						"SetFramerate"
 					]
 				},
 				"description": "Test steps:\n1) Execute get data format api to get the current fps values for current stream resolution \n2) Execute Get fps formats to see possible values of fps for each given resolution \n3) Execute set fps api with valid input"

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -252,7 +252,7 @@
 			"response": []
 		},
 		{
-			"name": "Get supported framerate formats",
+			"name": "Get supported frame rate formats",
 			"event": [
 				{
 					"listen": "test",
@@ -282,7 +282,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/FramerateFormats?PathIndex=0",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/FrameRateFormats?PathIndex=0",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -294,7 +294,7 @@
 						"device",
 						"name",
 						"{{camera_name}}",
-						"FramerateFormats"
+						"FrameRateFormats"
 					],
 					"query": [
 						{
@@ -552,7 +552,7 @@
 			"response": []
 		},
 		{
-			"name": "Get Framerate",
+			"name": "Get Frame Rate",
 			"event": [
 				{
 					"listen": "test",
@@ -582,7 +582,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/GetFramerate?PathIndex=0",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/GetFrameRate?PathIndex=0",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -594,7 +594,7 @@
 						"device",
 						"name",
 						"{{camera_name}}",
-						"GetFramerate"
+						"GetFrameRate"
 					],
 					"query": [
 						{
@@ -607,7 +607,7 @@
 			"response": []
 		},
 		{
-			"name": "Set Framerate",
+			"name": "Set Frame Rate",
 			"event": [
 				{
 					"listen": "test",
@@ -626,7 +626,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\"SetFramerate\": {\n        \"FpsValueDenominator\":\"15\",\n        \"FpsValueNumerator\":\"1\"\n    }\n}",
+					"raw": "{\n\"SetFrameRate\": {\n        \"FpsValueDenominator\":\"15\",\n        \"FpsValueNumerator\":\"1\"\n    }\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -634,7 +634,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/SetFramerate?PathIndex=0",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/SetFrameRate?PathIndex=0",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -646,7 +646,7 @@
 						"device",
 						"name",
 						"{{camera_name}}",
-						"SetFramerate"
+						"SetFrameRate"
 					],
 					"query": [
 						{

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -253,7 +253,7 @@
 			"response": []
 		},
 		{
-			"name": "Get supported fps formats",
+			"name": "Get supported framerate formats",
 			"event": [
 				{
 					"listen": "test",
@@ -547,7 +547,7 @@
 			"response": []
 		},
 		{
-			"name": "Set FPS",
+			"name": "Set Framerate",
 			"event": [
 				{
 					"listen": "test",
@@ -566,7 +566,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\"SetFramerate\":\n{\"FpsValueDenominator\":\"10\",\n{\"FpsValueNumerator\":\"1\"}\n}",
+					"raw": "{\"SetFramerate\":\n{\"FpsValueDenominator\":\"10\",\n\"FpsValueNumerator\":\"1\"}\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "0b15519a-2feb-4028-bdef-c91b7cb8b16c",
+		"_postman_id": "1cd1947d-95fa-456b-ae95-54b38b90723d",
 		"name": "USB-Camera-Collection",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -233,7 +233,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/DataFormat",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/DataFormat?PathIndex={{path_index}}",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -247,10 +247,10 @@
 						"{{camera_name}}",
 						"DataFormat"
 					],
-                    "query": [
+					"query": [
 						{
 							"key": "PathIndex",
-							"value": "0"
+							"value": "{{path_index}}"
 						}
 					]
 				}
@@ -288,7 +288,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/FrameRateFormats?PathIndex=0",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/FrameRateFormats?PathIndex={{path_index}}",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -305,7 +305,7 @@
 					"query": [
 						{
 							"key": "PathIndex",
-							"value": "0"
+							"value": "{{path_index}}"
 						}
 					]
 				}
@@ -588,7 +588,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/GetFrameRate?PathIndex=0",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/FrameRate?PathIndex={{path_index}}",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -600,12 +600,12 @@
 						"device",
 						"name",
 						"{{camera_name}}",
-						"GetFrameRate"
+						"FrameRate"
 					],
 					"query": [
 						{
 							"key": "PathIndex",
-							"value": "0"
+							"value": "{{path_index}}"
 						}
 					]
 				}
@@ -632,7 +632,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\"SetFrameRate\": {\n        \"FpsValueDenominator\":\"15\",\n        \"FpsValueNumerator\":\"1\"\n    }\n}",
+					"raw": "{\n\"FrameRate\": {\n        \"FpsValueDenominator\":\"30\",\n        \"FpsValueNumerator\":\"1\"\n    }\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -640,7 +640,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/SetFrameRate?PathIndex=0",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/FrameRate?PathIndex={{path_index}}",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -652,12 +652,12 @@
 						"device",
 						"name",
 						"{{camera_name}}",
-						"SetFrameRate"
+						"FrameRate"
 					],
 					"query": [
 						{
 							"key": "PathIndex",
-							"value": "0"
+							"value": "{{path_index}}"
 						}
 					]
 				},

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -566,7 +566,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\"SetFps\":\n{\"FpsValue\":\"5\"}\n}",
+					"raw": "{\"SetFps\":\n{\"FpsValueDenominator\":\"10\",\n{\"FpsValueNumerator\":\"1\"}\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "57da9c2a-e1d1-4c55-9ee4-304b0f4a8c8d",
+		"_postman_id": "0b15519a-2feb-4028-bdef-c91b7cb8b16c",
 		"name": "USB-Camera-Collection",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "19151794"
@@ -283,7 +283,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/FramerateFormats",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/FramerateFormats?PathIndex=0",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -296,6 +296,12 @@
 						"name",
 						"{{camera_name}}",
 						"FramerateFormats"
+					],
+					"query": [
+						{
+							"key": "PathIndex",
+							"value": "0"
+						}
 					]
 				}
 			},
@@ -547,6 +553,61 @@
 			"response": []
 		},
 		{
+			"name": "Get Framerate",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"  pm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/GetFramerate?PathIndex=0",
+					"protocol": "http",
+					"host": [
+						"{{command_host}}"
+					],
+					"port": "{{command_port}}",
+					"path": [
+						"api",
+						"v3",
+						"device",
+						"name",
+						"{{camera_name}}",
+						"GetFramerate"
+					],
+					"query": [
+						{
+							"key": "PathIndex",
+							"value": "0"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Set Framerate",
 			"event": [
 				{
@@ -566,7 +627,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\"SetFramerate\":\n{\"FpsValueDenominator\":\"10\",\n\"FpsValueNumerator\":\"1\"}\n}",
+					"raw": "{\n\"SetFramerate\": {\n        \"FpsValueDenominator\":\"15\",\n        \"FpsValueNumerator\":\"1\"\n    }\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -574,7 +635,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/SetFramerate",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/SetFramerate?PathIndex=0",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -587,6 +648,12 @@
 						"name",
 						"{{camera_name}}",
 						"SetFramerate"
+					],
+					"query": [
+						{
+							"key": "PathIndex",
+							"value": "0"
+						}
 					]
 				},
 				"description": "Test steps:\n1) Execute get data format api to get the current fps values for current stream resolution \n2) Execute Get fps formats to see possible values of fps for each given resolution \n3) Execute set fps api with valid input"

--- a/docs/USB_camera_env.postman_environment.json
+++ b/docs/USB_camera_env.postman_environment.json
@@ -49,6 +49,12 @@
 			"value": "device-usb-camera",
 			"type": "default",
 			"enabled": true
+		},
+        {
+			"key": "path_index",
+			"value": "0",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -25,6 +25,7 @@ const (
 	Stream                          = "stream"
 	PrefixInput                     = "Input"
 	PrefixOutput                    = "Output"
+	FpsValue                        = "FpsValue"
 
 	// API route specific to Device Service
 	ApiRefreshDevicePaths = "/refreshdevicepaths"
@@ -42,11 +43,12 @@ const (
 	MetadataCroppingAbility     = "METADATA_CROPPING_ABILITY"
 	MetadataStreamingParameters = "METADATA_STREAMING_PARAMETERS"
 	MetadataImageFormats        = "METADATA_IMAGE_FORMATS"
+	MetadataFpsFormats          = "METADATA_FPS_FORMATS"
 	VideoStartStreaming         = "VIDEO_START_STREAMING"
 	VideoStopStreaming          = "VIDEO_STOP_STREAMING"
 	VideoStreamUri              = "VIDEO_STREAM_URI"
 	VideoStreamingStatus        = "VIDEO_STREAMING_STATUS"
-	VideoSetFPS                 = "VIDEO_SET_FPS"
+	VideoSetFps                 = "VIDEO_SET_FPS"
 
 	// FFmpeg options
 	FFmpegFrames      = "-frames:d"
@@ -65,6 +67,7 @@ const (
 
 	// Input option names
 	InputPixelFormat = "InputPixelFormat"
+	InputFps         = "InputFps"
 
 	// udev device properties
 	UdevSerialShort = "ID_SERIAL_SHORT"

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -46,6 +46,7 @@ const (
 	VideoStopStreaming          = "VIDEO_STOP_STREAMING"
 	VideoStreamUri              = "VIDEO_STREAM_URI"
 	VideoStreamingStatus        = "VIDEO_STREAMING_STATUS"
+	VideoSetFPS                 = "VIDEO_SET_FPS"
 
 	// FFmpeg options
 	FFmpegFrames      = "-frames:d"

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -7,7 +7,8 @@
 package driver
 
 const (
-	Command                         = "command"
+	GetFunction                     = "getFunction"
+	SetFunction                     = "setFunction"
 	UsbProtocol                     = "USB"
 	Paths                           = "Paths"
 	SerialNumber                    = "SerialNumber"
@@ -50,8 +51,8 @@ const (
 	VideoStopStreaming          = "VIDEO_STOP_STREAMING"
 	VideoStreamUri              = "VIDEO_STREAM_URI"
 	VideoStreamingStatus        = "VIDEO_STREAMING_STATUS"
-	VideoSetFrameRate           = "VIDEO_SET_FRAMERATE"
 	VideoGetFrameRate           = "VIDEO_GET_FRAMERATE"
+	VideoSetFrameRate           = "VIDEO_SET_FRAMERATE"
 
 	// FFmpeg options
 	FFmpegFrames      = "-frames:d"

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -9,7 +9,6 @@ package driver
 const (
 	Command                         = "command"
 	UsbProtocol                     = "USB"
-	Path                            = "Path"
 	Paths                           = "Paths"
 	SerialNumber                    = "SerialNumber"
 	CardName                        = "CardName"
@@ -28,7 +27,6 @@ const (
 	PrefixOutput                    = "Output"
 	FpsValueDenominator             = "FpsValueDenominator"
 	FpsValueNumerator               = "FpsValueNumerator"
-	URLRawQuery                     = "urlRawQuery"
 	PathIndex                       = "PathIndex"
 
 	// API route specific to Device Service
@@ -72,10 +70,6 @@ const (
 
 	// Input option names
 	InputPixelFormat = "InputPixelFormat"
-	InputFps         = "InputFps"
-
-	// Output option names
-	OutputFps = "OutputFps"
 
 	// udev device properties
 	UdevSerialShort = "ID_SERIAL_SHORT"

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -49,6 +49,8 @@ const (
 	VideoStreamUri              = "VIDEO_STREAM_URI"
 	VideoStreamingStatus        = "VIDEO_STREAMING_STATUS"
 	VideoSetFps                 = "VIDEO_SET_FPS"
+	FpsValueDenominator         = "FpsValueDenominator"
+	FpsValueNumerator           = "FpsValueNumerator"
 
 	// FFmpeg options
 	FFmpegFrames      = "-frames:d"
@@ -68,6 +70,9 @@ const (
 	// Input option names
 	InputPixelFormat = "InputPixelFormat"
 	InputFps         = "InputFps"
+
+	// Output option names
+	OutputFps = "OutputFps"
 
 	// udev device properties
 	UdevSerialShort = "ID_SERIAL_SHORT"

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -26,17 +26,16 @@ const (
 	Stream                          = "stream"
 	PrefixInput                     = "Input"
 	PrefixOutput                    = "Output"
-	FpsValue                        = "FpsValue"
+	FpsValueDenominator             = "FpsValueDenominator"
+	FpsValueNumerator               = "FpsValueNumerator"
 
 	// API route specific to Device Service
 	ApiRefreshDevicePaths = "/refreshdevicepaths"
 
 	// Metadata descriptions
-	DescNotSpecified    = "not specified"
-	DescTimePerFrame    = "time per frame"
-	DescHighQuality     = "high quality"
-	FpsValueDenominator = "FpsValueDenominator"
-	FpsValueNumerator   = "FpsValueNumerator"
+	DescNotSpecified = "not specified"
+	DescTimePerFrame = "time per frame"
+	DescHighQuality  = "high quality"
 
 	// Command names
 	MetadataDeviceCapability    = "METADATA_DEVICE_CAPABILITY"
@@ -46,7 +45,7 @@ const (
 	MetadataCroppingAbility     = "METADATA_CROPPING_ABILITY"
 	MetadataStreamingParameters = "METADATA_STREAMING_PARAMETERS"
 	MetadataImageFormats        = "METADATA_IMAGE_FORMATS"
-	MetadataFpsFormats          = "METADATA_FPS_FORMATS"
+	MetadataFramerateFormats    = "METADATA_FRAMERATE_FORMATS"
 	VideoStartStreaming         = "VIDEO_START_STREAMING"
 	VideoStopStreaming          = "VIDEO_STOP_STREAMING"
 	VideoStreamUri              = "VIDEO_STREAM_URI"

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -9,6 +9,7 @@ package driver
 const (
 	Command                         = "command"
 	UsbProtocol                     = "USB"
+	Path                            = "Path"
 	Paths                           = "Paths"
 	SerialNumber                    = "SerialNumber"
 	CardName                        = "CardName"
@@ -31,9 +32,11 @@ const (
 	ApiRefreshDevicePaths = "/refreshdevicepaths"
 
 	// Metadata descriptions
-	DescNotSpecified = "not specified"
-	DescTimePerFrame = "time per frame"
-	DescHighQuality  = "high quality"
+	DescNotSpecified    = "not specified"
+	DescTimePerFrame    = "time per frame"
+	DescHighQuality     = "high quality"
+	FpsValueDenominator = "FpsValueDenominator"
+	FpsValueNumerator   = "FpsValueNumerator"
 
 	// Command names
 	MetadataDeviceCapability    = "METADATA_DEVICE_CAPABILITY"
@@ -49,8 +52,7 @@ const (
 	VideoStreamUri              = "VIDEO_STREAM_URI"
 	VideoStreamingStatus        = "VIDEO_STREAMING_STATUS"
 	VideoSetFramerate           = "VIDEO_SET_FRAMERATE"
-	FpsValueDenominator         = "FpsValueDenominator"
-	FpsValueNumerator           = "FpsValueNumerator"
+	VideoGetFramerate           = "VIDEO_GET_FRAMERATE"
 
 	// FFmpeg options
 	FFmpegFrames      = "-frames:d"

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -48,7 +48,7 @@ const (
 	VideoStopStreaming          = "VIDEO_STOP_STREAMING"
 	VideoStreamUri              = "VIDEO_STREAM_URI"
 	VideoStreamingStatus        = "VIDEO_STREAMING_STATUS"
-	VideoSetFps                 = "VIDEO_SET_FPS"
+	VideoSetFramerate           = "VIDEO_SET_FRAMERATE"
 	FpsValueDenominator         = "FpsValueDenominator"
 	FpsValueNumerator           = "FpsValueNumerator"
 

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -45,13 +45,13 @@ const (
 	MetadataCroppingAbility     = "METADATA_CROPPING_ABILITY"
 	MetadataStreamingParameters = "METADATA_STREAMING_PARAMETERS"
 	MetadataImageFormats        = "METADATA_IMAGE_FORMATS"
-	MetadataFramerateFormats    = "METADATA_FRAMERATE_FORMATS"
+	MetadataFrameRateFormats    = "METADATA_FRAMERATE_FORMATS"
 	VideoStartStreaming         = "VIDEO_START_STREAMING"
 	VideoStopStreaming          = "VIDEO_STOP_STREAMING"
 	VideoStreamUri              = "VIDEO_STREAM_URI"
 	VideoStreamingStatus        = "VIDEO_STREAMING_STATUS"
-	VideoSetFramerate           = "VIDEO_SET_FRAMERATE"
-	VideoGetFramerate           = "VIDEO_GET_FRAMERATE"
+	VideoSetFrameRate           = "VIDEO_SET_FRAMERATE"
+	VideoGetFrameRate           = "VIDEO_GET_FRAMERATE"
 
 	// FFmpeg options
 	FFmpegFrames      = "-frames:d"

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -26,8 +26,8 @@ const (
 	Stream                          = "stream"
 	PrefixInput                     = "Input"
 	PrefixOutput                    = "Output"
-	FrameRateValueDenominator       = "FpsValueDenominator"
-	FrameRateValueNumerator         = "FpsValueNumerator"
+	FrameRateValueDenominator       = "FrameRateValueDenominator"
+	FrameRateValueNumerator         = "FrameRateValueNumerator"
 	PathIndex                       = "PathIndex"
 
 	// API route specific to Device Service

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -26,8 +26,8 @@ const (
 	Stream                          = "stream"
 	PrefixInput                     = "Input"
 	PrefixOutput                    = "Output"
-	FpsValueDenominator             = "FpsValueDenominator"
-	FpsValueNumerator               = "FpsValueNumerator"
+	FrameRateValueDenominator       = "FpsValueDenominator"
+	FrameRateValueNumerator         = "FpsValueNumerator"
 	PathIndex                       = "PathIndex"
 
 	// API route specific to Device Service

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2022 Intel Corporation
+// Copyright (C) 2022-2023 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -29,6 +29,7 @@ const (
 	FpsValueDenominator             = "FpsValueDenominator"
 	FpsValueNumerator               = "FpsValueNumerator"
 	URLRawQuery                     = "urlRawQuery"
+	PathIndex                       = "PathIndex"
 
 	// API route specific to Device Service
 	ApiRefreshDevicePaths = "/refreshdevicepaths"

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -28,6 +28,7 @@ const (
 	PrefixOutput                    = "Output"
 	FpsValueDenominator             = "FpsValueDenominator"
 	FpsValueNumerator               = "FpsValueNumerator"
+	URLRawQuery                     = "urlRawQuery"
 
 	// API route specific to Device Service
 	ApiRefreshDevicePaths = "/refreshdevicepaths"

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -99,7 +99,7 @@ func (dev *Device) SetFrameRate(usbDevice *usbdevice.Device, intervalNumerator u
 		return "", err
 	}
 	found := false
-	for _, frameRate := range dataFormat.(DataFormat).FpsIntervals {
+	for _, frameRate := range dataFormat.(DataFormat).FrameRates {
 		if intervalNumerator == frameRate.Denominator && intervalDenominator == frameRate.Numerator {
 			found = true
 			break

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -128,9 +128,7 @@ func (dev *Device) SetFps(fpsNumerator uint32, fpsDenominator uint32) (string, e
 	if err != nil {
 		return "", err
 	}
-	// Set input fps for ffmpeg to match new device fps
-	dev.updateFFmpegOptions(InputFps, fps)
-	dev.updateFFmpegOptions(OutputFps, fps)
+
 	return fps, nil
 }
 

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -94,7 +94,6 @@ func (dev *Device) StopStreaming() {
 // SetFps updates the fps on the device side of the service. Note that this won't update the rtsp output stream fps
 func (dev *Device) SetFps(device *usbdevice.Device, fpsNumerator uint32, fpsDenominator uint32) (string, error) {
 	fps := fmt.Sprintf("%f", float32(fpsDenominator)/float32(fpsNumerator))
-
 	dataFormat, err := getDataFormat(device)
 	if err != nil {
 		return "", nil

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -129,7 +129,11 @@ func (dev *Device) GetFrameRate(usbdevice *usbdevice.Device) (v4l2.Fract, error)
 	if err != nil {
 		return v4l2.Fract{}, err
 	}
-	return streamParam.Capture.TimePerFrame, nil
+	timePerFrame := streamParam.Capture.TimePerFrame
+	var fps v4l2.Fract
+	fps.Denominator = timePerFrame.Numerator
+	fps.Numerator = timePerFrame.Denominator
+	return fps, nil
 }
 
 func (dev *Device) updateFFmpegOptions(optName, optVal string) {

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -114,7 +114,7 @@ func (dev *Device) SetFps(fpsNumerator uint32, fpsDenominator uint32) (string, e
 		}
 	}
 	if !foundFlag {
-		return "", errors.NewCommonEdgeX(errors.KindCommunicationError, fmt.Sprintf("FPS value %d not supported for current image format.", fps), nil)
+		return "", errors.NewCommonEdgeX(errors.KindCommunicationError, fmt.Sprintf("FPS value %s not supported for current image format.", fps), nil)
 	}
 
 	// Update device fps for stream parameters

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -92,15 +92,15 @@ func (dev *Device) StopStreaming() {
 }
 
 // SetFrameRate updates the fps on the device side of the service. Note that this won't update the rtsp output stream fps
-func (dev *Device) SetFrameRate(usbDevice *usbdevice.Device, intervalNumerator uint32, intervalDenominator uint32) (string, error) {
-	fps := fmt.Sprintf("%f", float32(intervalDenominator)/float32(intervalNumerator))
+func (dev *Device) SetFrameRate(usbDevice *usbdevice.Device, frameRateNumerator uint32, frameRateDenominator uint32) (string, error) {
+	fps := fmt.Sprintf("%f", float32(frameRateNumerator)/float32(frameRateDenominator))
 	dataFormat, err := getDataFormat(usbDevice)
 	if err != nil {
 		return "", err
 	}
 	found := false
 	for _, frameRate := range dataFormat.(DataFormat).FrameRates {
-		if intervalNumerator == frameRate.Denominator && intervalDenominator == frameRate.Numerator {
+		if frameRateNumerator == frameRate.Numerator && frameRateDenominator == frameRate.Denominator {
 			found = true
 			break
 		}
@@ -114,8 +114,10 @@ func (dev *Device) SetFrameRate(usbDevice *usbdevice.Device, intervalNumerator u
 	if err != nil {
 		return "", err
 	}
-	origStreamParam.Capture.TimePerFrame.Denominator = intervalDenominator
-	origStreamParam.Capture.TimePerFrame.Numerator = intervalNumerator
+	// this swaps user-friendly frame rate (frames per second) to
+	// the internally track frame interval (seconds per frame)
+	origStreamParam.Capture.TimePerFrame.Denominator = frameRateNumerator
+	origStreamParam.Capture.TimePerFrame.Numerator = frameRateDenominator
 	err = usbDevice.SetStreamParam(origStreamParam)
 	if err != nil {
 		return "", err

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -16,7 +16,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
 
-	"github.com/vladimirvivien/go4vl/device"
+	usbdevice "github.com/vladimirvivien/go4vl/device"
 	"github.com/vladimirvivien/go4vl/v4l2"
 
 	"github.com/xfrr/goffmpeg/transcoder"
@@ -92,13 +92,7 @@ func (dev *Device) StopStreaming() {
 }
 
 // SetFps updates the fps on the device side of the service. Note that this won't update the rtsp output stream fps
-func (dev *Device) SetFps(fpsNumerator uint32, fpsDenominator uint32) (string, error) {
-	devPath := dev.paths[0]
-	device, err := device.Open(devPath)
-	if err != nil {
-		return "", err
-	}
-	defer device.Close()
+func (dev *Device) SetFps(device *usbdevice.Device, fpsNumerator uint32, fpsDenominator uint32) (string, error) {
 	fps := fmt.Sprintf("%f", float32(fpsDenominator)/float32(fpsNumerator))
 
 	dataFormat, err := getDataFormat(device)

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -91,16 +91,16 @@ func (dev *Device) StopStreaming() {
 	}
 }
 
-// SetFps updates the fps on the device side of the service. Note that this won't update the rtsp output stream fps
-func (dev *Device) SetFrameRate(usbdevice *usbdevice.Device, fpsNumerator uint32, fpsDenominator uint32) (string, error) {
-	fps := fmt.Sprintf("%f", float32(fpsDenominator)/float32(fpsNumerator))
-	dataFormat, err := getDataFormat(usbdevice)
+// SetFrameRate updates the fps on the device side of the service. Note that this won't update the rtsp output stream fps
+func (dev *Device) SetFrameRate(usbDevice *usbdevice.Device, intervalNumerator uint32, intervalDenominator uint32) (string, error) {
+	fps := fmt.Sprintf("%f", float32(intervalDenominator)/float32(intervalNumerator))
+	dataFormat, err := getDataFormat(usbDevice)
 	if err != nil {
 		return "", err
 	}
 	found := false
-	for _, interval := range dataFormat.(DataFormat).FpsIntervals {
-		if fpsNumerator == interval.Numerator && fpsDenominator == interval.Denominator {
+	for _, frameRate := range dataFormat.(DataFormat).FpsIntervals {
+		if intervalNumerator == frameRate.Denominator && intervalDenominator == frameRate.Numerator {
 			found = true
 			break
 		}
@@ -110,13 +110,13 @@ func (dev *Device) SetFrameRate(usbdevice *usbdevice.Device, fpsNumerator uint32
 	}
 
 	// Update device fps for stream parameters
-	origStreamParam, err := usbdevice.GetStreamParam()
+	origStreamParam, err := usbDevice.GetStreamParam()
 	if err != nil {
 		return "", err
 	}
-	origStreamParam.Capture.TimePerFrame.Denominator = fpsDenominator
-	origStreamParam.Capture.TimePerFrame.Numerator = fpsNumerator
-	err = usbdevice.SetStreamParam(origStreamParam)
+	origStreamParam.Capture.TimePerFrame.Denominator = intervalDenominator
+	origStreamParam.Capture.TimePerFrame.Numerator = intervalNumerator
+	err = usbDevice.SetStreamParam(origStreamParam)
 	if err != nil {
 		return "", err
 	}
@@ -124,8 +124,8 @@ func (dev *Device) SetFrameRate(usbdevice *usbdevice.Device, fpsNumerator uint32
 	return fps, nil
 }
 
-func (dev *Device) GetFrameRate(usbdevice *usbdevice.Device) (v4l2.Fract, error) {
-	streamParam, err := usbdevice.GetStreamParam()
+func (dev *Device) GetFrameRate(usbDevice *usbdevice.Device) (v4l2.Fract, error) {
+	streamParam, err := usbDevice.GetStreamParam()
 	if err != nil {
 		return v4l2.Fract{}, err
 	}

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -92,7 +92,7 @@ func (dev *Device) StopStreaming() {
 }
 
 // SetFps updates the fps on the device side of the service. Note that this won't update the rtsp output stream fps
-func (dev *Device) SetFps(usbdevice *usbdevice.Device, fpsNumerator uint32, fpsDenominator uint32) (string, error) {
+func (dev *Device) SetFrameRate(usbdevice *usbdevice.Device, fpsNumerator uint32, fpsDenominator uint32) (string, error) {
 	fps := fmt.Sprintf("%f", float32(fpsDenominator)/float32(fpsNumerator))
 	dataFormat, err := getDataFormat(usbdevice)
 	if err != nil {
@@ -122,6 +122,14 @@ func (dev *Device) SetFps(usbdevice *usbdevice.Device, fpsNumerator uint32, fpsD
 	}
 
 	return fps, nil
+}
+
+func (dev *Device) GetFrameRate(usbdevice *usbdevice.Device) (v4l2.Fract, error) {
+	streamParam, err := usbdevice.GetStreamParam()
+	if err != nil {
+		return v4l2.Fract{}, err
+	}
+	return streamParam.Capture.TimePerFrame, nil
 }
 
 func (dev *Device) updateFFmpegOptions(optName, optVal string) {

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -370,6 +370,16 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 		} else {
 			path = "/dev/video" + pathIndex
 		}
+		pathExists := false
+		for _, currentPath := range device.paths {
+			if currentPath == path {
+				pathExists = true
+				break
+			}
+		}
+		if !pathExists {
+			return errors.NewCommonEdgeX(errors.KindIOError, fmt.Sprintf("Path Index %s not valid for selected device %s", path, deviceName), nil)
+		}
 
 		// currently defaults to using the first available stream
 		cameraDevice, err := usbdevice.Open(path)

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -418,31 +418,31 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 		case VideoStopStreaming:
 			device.StopStreaming()
 		case VideoSetFrameRate:
-			fpsParam, edgexErr := params[i].ObjectValue()
+			intervalParam, edgexErr := params[i].ObjectValue()
 			if edgexErr != nil {
 				return errors.NewCommonEdgeXWrapper(edgexErr)
 			}
-			fpsValueDenominator, ok := fpsParam.(map[string]interface{})[FpsValueDenominator]
+			intervalValueDenominator, ok := intervalParam.(map[string]interface{})[FpsValueNumerator]
 			if !ok {
 				return errors.NewCommonEdgeXWrapper(nil)
 			}
-			fpsDenominator, err := strconv.ParseUint(fpsValueDenominator.(string), 0, 32)
+			intervalDenominator, err := strconv.ParseUint(intervalValueDenominator.(string), 0, 32)
 			if err != nil {
-				d.lc.Errorf("Could not parse denominator %d to uint32", fpsDenominator)
+				d.lc.Errorf("Could not parse denominator %d to uint32", intervalDenominator)
 				return err
 			}
-			var fpsNumerator uint64
-			fpsValueNumerator, ok := fpsParam.(map[string]interface{})[FpsValueNumerator]
+			var intervalNumerator uint64
+			intervalValueNumerator, ok := intervalParam.(map[string]interface{})[FpsValueDenominator]
 			if !ok {
-				fpsNumerator = 1
+				intervalNumerator = 1
 			} else {
-				fpsNumerator, err = strconv.ParseUint(fpsValueNumerator.(string), 0, 32)
+				intervalNumerator, err = strconv.ParseUint(intervalValueNumerator.(string), 0, 32)
 				if err != nil {
-					d.lc.Errorf("Could not parse numerator %d to uint32", fpsNumerator)
+					d.lc.Errorf("Could not parse numerator %d to uint32", intervalNumerator)
 					return err
 				}
 			}
-			fps, err := device.SetFrameRate(cameraDevice, uint32(fpsNumerator), uint32(fpsDenominator))
+			fps, err := device.SetFrameRate(cameraDevice, uint32(intervalNumerator), uint32(intervalDenominator))
 			if err != nil {
 				d.lc.Errorf("Could not set the FPS to %f for device %s due to error: %s", fps, deviceName, err)
 				return err

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -357,7 +357,7 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 			}
 		case VideoStopStreaming:
 			device.StopStreaming()
-		case VideoSetFps:
+		case VideoSetFramerate:
 			fpsParam, edgexErr := params[i].ObjectValue()
 			if edgexErr != nil {
 				return errors.NewCommonEdgeXWrapper(edgexErr)
@@ -387,7 +387,7 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 				d.lc.Errorf("Could not set the FPS to %f for device %s due to error: %s", fps, deviceName, err)
 				return err
 			}
-			d.lc.Infof("Device FPS set to %s", fps)
+			d.lc.Infof("Device framerate set to %s", fps)
 		default:
 			return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("unsupported command %s", command), nil)
 		}

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -298,7 +298,7 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 				return responses, errorWrapper.CommandError(command, err)
 			}
 			cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeObject, data)
-		case MetadataFpsFormats:
+		case MetadataFramerateFormats:
 			data, err = getSupportedIntervalFormats(cameraDevice)
 			if err != nil {
 				return responses, errorWrapper.CommandError(command, err)

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -249,6 +249,7 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 			return responses, errors.NewCommonEdgeXWrapper(edgexErr)
 		}
 
+		// flush out the query so it resets with new calls
 		if _, ok := req.Attributes[UrlRawQuery]; ok {
 			req.Attributes[UrlRawQuery] = ""
 		}
@@ -269,11 +270,11 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 			videoPath = device.paths[pathIndexConv]
 		}
 
-		// currently defaults to using the first available stream
+		// currently defaults to using the first available stream if the user does not provide input
 		cameraDevice, err := usbDevice.Open(videoPath)
 		if err != nil {
 			return responses, errors.NewCommonEdgeX(errors.KindServerError,
-				fmt.Sprintf("failed to open the underlying device at specified path %s", videoPath), err)
+				fmt.Sprintf("failed to open the underlying device for streaming at specified path %s", videoPath), err)
 		}
 		defer cameraDevice.Close()
 
@@ -380,7 +381,7 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 		var videoPath string
 		pathIndex := queryParams.Get(PathIndex)
 		if len(pathIndex) == 0 {
-			// currently defaults to using the first available stream
+			// currently defaults to using the first available stream if the user does not provide input
 			videoPath = device.paths[0]
 		} else {
 			pathIndexConv, err := strconv.Atoi(pathIndex)
@@ -397,7 +398,7 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 		cameraDevice, err := usbDevice.Open(videoPath)
 		if err != nil {
 			return errors.NewCommonEdgeX(errors.KindServerError,
-				fmt.Sprintf("failed to open the underlying device at specified path %s", videoPath), err)
+				fmt.Sprintf("failed to open the underlying device for streaming at specified path %s", videoPath), err)
 		}
 		defer cameraDevice.Close()
 

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -416,25 +416,26 @@ func (d *Driver) ExecuteWriteCommands(device *Device, req sdkModels.CommandReque
 		if edgexErr != nil {
 			return errors.NewCommonEdgeXWrapper(edgexErr)
 		}
+		var frameRateDenominator uint64
 		frameRateValueDenominator, ok := frameRateParam.(map[string]interface{})[FrameRateValueDenominator]
+		if !ok {
+			frameRateDenominator = 1
+		} else {
+			frameRateDenominator, err = strconv.ParseUint(frameRateValueDenominator.(string), 0, 32)
+			if err != nil {
+				d.lc.Errorf("Could not parse numerator %d to uint32", frameRateValueDenominator)
+				return err
+			}
+		}
+
+		frameRateValueNumerator, ok := frameRateParam.(map[string]interface{})[FrameRateValueNumerator]
 		if !ok {
 			return errors.NewCommonEdgeXWrapper(nil)
 		}
-		frameRateDenominator, err := strconv.ParseUint(frameRateValueDenominator.(string), 0, 32)
+		frameRateNumerator, err := strconv.ParseUint(frameRateValueNumerator.(string), 0, 32)
 		if err != nil {
-			d.lc.Errorf("Could not parse denominator %d to uint32", frameRateDenominator)
+			d.lc.Errorf("Could not parse denominator %d to uint32", frameRateNumerator)
 			return err
-		}
-		var frameRateNumerator uint64
-		frameRateValueNumerator, ok := frameRateParam.(map[string]interface{})[FrameRateValueDenominator]
-		if !ok {
-			frameRateNumerator = 1
-		} else {
-			frameRateNumerator, err = strconv.ParseUint(frameRateValueNumerator.(string), 0, 32)
-			if err != nil {
-				d.lc.Errorf("Could not parse numerator %d to uint32", frameRateNumerator)
-				return err
-			}
 		}
 		fps, err := device.SetFrameRate(cameraDevice, uint32(frameRateNumerator), uint32(frameRateDenominator))
 		if err != nil {

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -250,8 +250,9 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 			return responses, errors.NewCommonEdgeXWrapper(edgexErr)
 		}
 
-		// flush out the query so it resets with new calls
-		req.Attributes[UrlRawQuery] = ""
+		if _, ok := req.Attributes[UrlRawQuery]; ok {
+			req.Attributes[UrlRawQuery] = ""
+		}
 
 		var path string
 		pathIndex := queryParams.Get(PathIndex)
@@ -291,10 +292,6 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 			}
 			cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeInt32, data)
 		case MetadataCameraStatus:
-			queryParams, edgexErr := getQueryParameters(req)
-			if edgexErr != nil {
-				return responses, errors.NewCommonEdgeXWrapper(edgexErr)
-			}
 			index := queryParams.Get(InputIndex)
 			if len(index) == 0 {
 				return responses, fmt.Errorf("mandatory query parameter %s not found", InputIndex)
@@ -377,7 +374,9 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 		}
 
 		// flush out the query so it resets with new calls
-		req.Attributes[UrlRawQuery] = ""
+		if _, ok := req.Attributes[UrlRawQuery]; ok {
+			req.Attributes[UrlRawQuery] = ""
+		}
 
 		var path string
 		pathIndex := queryParams.Get(PathIndex)

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -254,17 +254,15 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 		if len(pathIndex) == 0 {
 			path = device.paths[0]
 		} else {
-			path = "/dev/video" + pathIndex
-		}
-		pathExists := false
-		for _, currentPath := range device.paths {
-			if currentPath == path {
-				pathExists = true
-				break
+			pathIndexConv, err := strconv.Atoi(pathIndex)
+			if err != nil {
+				return nil, err
 			}
-		}
-		if !pathExists {
-			return nil, errors.NewCommonEdgeX(errors.KindIOError, fmt.Sprintf("Path Index %s not valid for selected device %s", path, deviceName), nil)
+			if pathIndexConv >= len(device.paths) {
+				return nil, errors.NewCommonEdgeX(errors.KindIOError,
+					fmt.Sprintf("PathIndex %d exceeds array bounds", pathIndexConv), nil)
+			}
+			path = device.paths[pathIndexConv]
 		}
 
 		// currently defaults to using the first available stream
@@ -378,17 +376,15 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 		if len(pathIndex) == 0 {
 			path = device.paths[0]
 		} else {
-			path = "/dev/video" + pathIndex
-		}
-		pathExists := false
-		for _, currentPath := range device.paths {
-			if currentPath == path {
-				pathExists = true
-				break
+			pathIndexConv, err := strconv.Atoi(pathIndex)
+			if err != nil {
+				return err
 			}
-		}
-		if !pathExists {
-			return errors.NewCommonEdgeX(errors.KindIOError, fmt.Sprintf("Path Index %s not valid for selected device %s", path, deviceName), nil)
+			if pathIndexConv >= len(device.paths) {
+				return errors.NewCommonEdgeX(errors.KindIOError,
+					fmt.Sprintf("PathIndex %d exceeds array bounds", pathIndexConv), nil)
+			}
+			path = device.paths[pathIndexConv]
 		}
 
 		// currently defaults to using the first available stream

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -351,6 +351,27 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 			}
 		case VideoStopStreaming:
 			device.StopStreaming()
+		case VideoSetFPS:
+			fpsParam, edgexErr := params[i].ObjectValue()
+			if edgexErr != nil {
+				return errors.NewCommonEdgeXWrapper(edgexErr)
+			}
+			fpsValue, ok := fpsParam.(map[string]interface{})["FPSValue"]
+			if !ok {
+				return edgexErr
+			}
+			fps, err := strconv.ParseUint(fpsValue.(string), 0, 32)
+			if err != nil {
+				d.lc.Errorf("Could not parse FPSValue %d to uint32", fps)
+				return err
+			}
+			var frames uint32
+			frames, err = device.SetFPS(uint32(fps))
+			if err != nil {
+				d.lc.Errorf("Could not set the FPS to %d for device %s", fps, deviceName)
+				return err
+			}
+			d.lc.Infof("Video FPS set to %d", frames)
 		default:
 			return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("unsupported command %s", command), nil)
 		}

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -313,7 +313,7 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 			}
 			cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeObject, data)
 		case VideoGetFrameRate:
-			data, err = cameraDevice.GetFrameRate()
+			data, err = device.GetFrameRate(cameraDevice)
 			if err != nil {
 				return responses, errorWrapper.CommandError(command, err)
 			}
@@ -442,7 +442,7 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 					return err
 				}
 			}
-			fps, err := device.SetFps(cameraDevice, uint32(fpsNumerator), uint32(fpsDenominator))
+			fps, err := device.SetFrameRate(cameraDevice, uint32(fpsNumerator), uint32(fpsDenominator))
 			if err != nil {
 				d.lc.Errorf("Could not set the FPS to %f for device %s due to error: %s", fps, deviceName, err)
 				return err

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -368,7 +368,7 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 			var frames uint32
 			frames, err = device.SetFPS(uint32(fps))
 			if err != nil {
-				d.lc.Errorf("Could not set the FPS to %d for device %s", fps, deviceName)
+				d.lc.Errorf("Could not set the FPS to %d for device %s due to error: %s", fps, deviceName, err)
 				return err
 			}
 			d.lc.Infof("Video FPS set to %d", frames)
@@ -915,4 +915,17 @@ func (d *Driver) ValidateDevice(device models.Device) error {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 	return nil
+}
+
+func (d *Driver) getSupportedFormats(devPath string) {
+	cmd := exec.Command("v4l2-ctl", "-d", devPath, "--list-formats-ex")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return
+	}
+	props := strings.Split(string(output), "\n")
+	// var x map[string](map[string][]string)
+	for _, line := range props {
+		d.lc.Info(line)
+	}
 }

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -226,7 +226,6 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 	reqs []sdkModels.CommandRequest) ([]*sdkModels.CommandValue, error) {
 	d.lc.Debugf("Driver.HandleReadCommands: protocols: %v resource: %v attributes: %v", protocols,
 		reqs[0].DeviceResourceName, reqs[0].Attributes)
-	// var err error
 	var responses = make([]*sdkModels.CommandValue, len(reqs))
 
 	device, edgexErr := d.getDevice(deviceName)
@@ -238,7 +237,7 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 	var data interface{}
 	errorWrapper := EdgeXErrorWrapper{}
 	for i, req := range reqs {
-		command, ok := req.Attributes[Command]
+		command, ok := req.Attributes[GetFunction]
 		if !ok {
 			return responses, errors.NewCommonEdgeX(errors.KindContractInvalid,
 				fmt.Sprintf("command for USB camera resource %s is not specified, please check device profile",
@@ -362,7 +361,7 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 	}
 
 	for i, req := range reqs {
-		command, ok := req.Attributes[Command]
+		command, ok := req.Attributes[SetFunction]
 		if !ok {
 			return errors.NewCommonEdgeX(errors.KindContractInvalid,
 				fmt.Sprintf("command for USB camera resource %s is not specified, please check device profile",
@@ -381,6 +380,7 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 		var videoPath string
 		pathIndex := queryParams.Get(PathIndex)
 		if len(pathIndex) == 0 {
+			// currently defaults to using the first available stream
 			videoPath = device.paths[0]
 		} else {
 			pathIndexConv, err := strconv.Atoi(pathIndex)
@@ -394,7 +394,6 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 			videoPath = device.paths[pathIndexConv]
 		}
 
-		// currently defaults to using the first available stream
 		cameraDevice, err := usbDevice.Open(videoPath)
 		if err != nil {
 			return errors.NewCommonEdgeX(errors.KindServerError,
@@ -725,7 +724,7 @@ func (d *Driver) newDevice(name string, protocols map[string]models.ProtocolProp
 
 	var streamingStatusResourceName string
 	for _, r := range profile.DeviceResources {
-		command, ok := r.Attributes[Command]
+		command, ok := r.Attributes[GetFunction]
 		if ok && command == VideoStreamingStatus {
 			streamingStatusResourceName = r.Name
 			break

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -249,8 +249,12 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 		if edgexErr != nil {
 			return responses, errors.NewCommonEdgeXWrapper(edgexErr)
 		}
+
+		// flush out the query so it resets with new calls
+		req.Attributes[UrlRawQuery] = ""
+
 		var path string
-		pathIndex := queryParams.Get("PathIndex")
+		pathIndex := queryParams.Get(PathIndex)
 		if len(pathIndex) == 0 {
 			path = device.paths[0]
 		} else {
@@ -348,8 +352,6 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 			return responses, errors.NewCommonEdgeX(errors.KindServerError, "failed to create CommandValue", err)
 		}
 		responses[i] = cv
-		// flush out the query so it resets with new calls
-		req.Attributes[UrlRawQuery] = ""
 	}
 
 	return responses, nil
@@ -373,8 +375,12 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 		if edgexErr != nil {
 			return errors.NewCommonEdgeXWrapper(edgexErr)
 		}
+
+		// flush out the query so it resets with new calls
+		req.Attributes[UrlRawQuery] = ""
+
 		var path string
-		pathIndex := queryParams.Get("PathIndex")
+		pathIndex := queryParams.Get(PathIndex)
 		if len(pathIndex) == 0 {
 			path = device.paths[0]
 		} else {
@@ -447,8 +453,6 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 		default:
 			return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("unsupported command %s", command), nil)
 		}
-		// flush out the query so it resets with new calls
-		req.Attributes[UrlRawQuery] = ""
 	}
 
 	return nil

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -256,6 +256,16 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 		} else {
 			path = "/dev/video" + pathIndex
 		}
+		pathExists := false
+		for _, currentPath := range device.paths {
+			if currentPath == path {
+				pathExists = true
+				break
+			}
+		}
+		if !pathExists {
+			return nil, errors.NewCommonEdgeX(errors.KindIOError, fmt.Sprintf("Path Index %s not valid for selected device %s", path, deviceName), nil)
+		}
 
 		// currently defaults to using the first available stream
 		cameraDevice, err := usbdevice.Open(path)

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -260,7 +260,7 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 			}
 			if pathIndexConv >= len(device.paths) {
 				return nil, errors.NewCommonEdgeX(errors.KindIOError,
-					fmt.Sprintf("PathIndex %d exceeds array bounds", pathIndexConv), nil)
+					fmt.Sprintf("Video streaming path does not exist for the device %v at PathIndex %d", device.name, pathIndexConv), nil)
 			}
 			path = device.paths[pathIndexConv]
 		}

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -298,13 +298,13 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 				return responses, errorWrapper.CommandError(command, err)
 			}
 			cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeObject, data)
-		case MetadataFramerateFormats:
+		case MetadataFrameRateFormats:
 			data, err = getSupportedIntervalFormats(cameraDevice)
 			if err != nil {
 				return responses, errorWrapper.CommandError(command, err)
 			}
 			cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeObject, data)
-		case VideoGetFramerate:
+		case VideoGetFrameRate:
 			data, err = cameraDevice.GetFrameRate()
 			if err != nil {
 				return responses, errorWrapper.CommandError(command, err)
@@ -395,7 +395,7 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 			}
 		case VideoStopStreaming:
 			device.StopStreaming()
-		case VideoSetFramerate:
+		case VideoSetFrameRate:
 			fpsParam, edgexErr := params[i].ObjectValue()
 			if edgexErr != nil {
 				return errors.NewCommonEdgeXWrapper(edgexErr)
@@ -425,7 +425,7 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 				d.lc.Errorf("Could not set the FPS to %f for device %s due to error: %s", fps, deviceName, err)
 				return err
 			}
-			d.lc.Infof("Device framerate set to %s", fps)
+			d.lc.Infof("Device frame rate set to %s", fps)
 		default:
 			return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("unsupported command %s", command), nil)
 		}

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -348,6 +348,8 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 			return responses, errors.NewCommonEdgeX(errors.KindServerError, "failed to create CommandValue", err)
 		}
 		responses[i] = cv
+		// flush out the query so it resets with new calls
+		req.Attributes[UrlRawQuery] = ""
 	}
 
 	return responses, nil
@@ -445,6 +447,8 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 		default:
 			return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("unsupported command %s", command), nil)
 		}
+		// flush out the query so it resets with new calls
+		req.Attributes[UrlRawQuery] = ""
 	}
 
 	return nil

--- a/internal/driver/ffmpeg.go
+++ b/internal/driver/ffmpeg.go
@@ -127,7 +127,7 @@ func setupFFmpegOptions(dev *Device, opts interface{}, attr map[string]interface
 
 	// obtain default FFmpeg options defined in resource attributes
 	for name, value := range attr {
-		if name == Command {
+		if name == SetFunction {
 			continue
 		}
 		optName := strings.ReplaceAll(name, "default", "")

--- a/internal/driver/metadata.go
+++ b/internal/driver/metadata.go
@@ -142,7 +142,7 @@ func getDataFormat(d *usbdevice.Device) (interface{}, error) {
 		fd := d.Fd()
 		index := uint32(intervalCount)
 		encoding := pixFmt.PixelFormat
-		if interval, exit := v4l2.GetFormatFrameInterval(fd, index, encoding, pixFmt.Width, pixFmt.Height); exit == nil {
+		if interval, err := v4l2.GetFormatFrameInterval(fd, index, encoding, pixFmt.Width, pixFmt.Height); err == nil {
 			intervalCount += 1
 			intervals = append(intervals, interval.Interval.Max)
 		} else {

--- a/internal/driver/metadata.go
+++ b/internal/driver/metadata.go
@@ -34,7 +34,7 @@ type DataFormat struct {
 	XferFunc     string
 	YcbcrEnc     string
 	Quantization string
-	FpsIntervals []v4l2.Fract
+	FrameRates   []v4l2.Fract
 }
 
 type CaptureMode struct {
@@ -137,14 +137,14 @@ func getDataFormat(d *usbdevice.Device) (interface{}, error) {
 	}
 	result.Quantization = quant
 	intervalCount := 0
-	var intervals []v4l2.Fract
+	var frameRates []v4l2.Fract
 	for {
 		fd := d.Fd()
 		index := uint32(intervalCount)
 		encoding := pixFmt.PixelFormat
 		if interval, err := v4l2.GetFormatFrameInterval(fd, index, encoding, pixFmt.Width, pixFmt.Height); err == nil {
 			intervalCount += 1
-			intervals = append(intervals, v4l2.Fract{
+			frameRates = append(frameRates, v4l2.Fract{
 				Denominator: interval.Interval.Max.Numerator,
 				Numerator:   interval.Interval.Max.Denominator,
 			})
@@ -152,7 +152,7 @@ func getDataFormat(d *usbdevice.Device) (interface{}, error) {
 			break
 		}
 	}
-	result.FpsIntervals = intervals
+	result.FrameRates = frameRates
 
 	return result, nil
 }

--- a/internal/driver/metadata.go
+++ b/internal/driver/metadata.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2022 Intel Corporation
+// Copyright (C) 2022-2023 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/internal/driver/metadata.go
+++ b/internal/driver/metadata.go
@@ -101,35 +101,35 @@ func getInputStatus(d *usbdevice.Device, index string) (uint32, error) {
 }
 
 func getDataFormat(d *usbdevice.Device) (interface{}, error) {
-	fmt, err := d.GetPixFormat()
+	pixFmt, err := d.GetPixFormat()
 	if err != nil {
 		return nil, err
 	}
 
 	result := DataFormat{}
-	result.Height = fmt.Height
-	result.Width = fmt.Width
-	result.PixelFormat = v4l2.PixelFormats[fmt.PixelFormat]
-	result.Field = v4l2.Fields[fmt.Field]
-	result.BytesPerLine = fmt.BytesPerLine
-	result.SizeImage = fmt.SizeImage
-	result.Colorspace = v4l2.Colorspaces[fmt.Colorspace]
+	result.Height = pixFmt.Height
+	result.Width = pixFmt.Width
+	result.PixelFormat = v4l2.PixelFormats[pixFmt.PixelFormat]
+	result.Field = v4l2.Fields[pixFmt.Field]
+	result.BytesPerLine = pixFmt.BytesPerLine
+	result.SizeImage = pixFmt.SizeImage
+	result.Colorspace = v4l2.Colorspaces[pixFmt.Colorspace]
 
-	xfunc := v4l2.XferFunctions[fmt.XferFunc]
-	if fmt.XferFunc == v4l2.XferFuncDefault {
-		xfunc = v4l2.XferFunctions[v4l2.ColorspaceToXferFunc(fmt.XferFunc)]
+	xfunc := v4l2.XferFunctions[pixFmt.XferFunc]
+	if pixFmt.XferFunc == v4l2.XferFuncDefault {
+		xfunc = v4l2.XferFunctions[v4l2.ColorspaceToXferFunc(pixFmt.XferFunc)]
 	}
 	result.XferFunc = xfunc
 
-	ycbcr := v4l2.YCbCrEncodings[fmt.YcbcrEnc]
-	if fmt.YcbcrEnc == v4l2.YCbCrEncodingDefault {
-		ycbcr = v4l2.YCbCrEncodings[v4l2.ColorspaceToYCbCrEnc(fmt.YcbcrEnc)]
+	ycbcr := v4l2.YCbCrEncodings[pixFmt.YcbcrEnc]
+	if pixFmt.YcbcrEnc == v4l2.YCbCrEncodingDefault {
+		ycbcr = v4l2.YCbCrEncodings[v4l2.ColorspaceToYCbCrEnc(pixFmt.YcbcrEnc)]
 	}
 	result.YcbcrEnc = ycbcr
 
-	quant := v4l2.Quantizations[fmt.Quantization]
-	if fmt.Quantization == v4l2.QuantizationDefault {
-		if v4l2.IsPixYUVEncoded(fmt.PixelFormat) {
+	quant := v4l2.Quantizations[pixFmt.Quantization]
+	if pixFmt.Quantization == v4l2.QuantizationDefault {
+		if v4l2.IsPixYUVEncoded(pixFmt.PixelFormat) {
 			quant = v4l2.Quantizations[v4l2.QuantizationLimitedRange]
 		} else {
 			quant = v4l2.Quantizations[v4l2.QuantizationFullRange]
@@ -141,8 +141,8 @@ func getDataFormat(d *usbdevice.Device) (interface{}, error) {
 	for {
 		fd := d.Fd()
 		index := uint32(intervalCount)
-		encoding := fmt.PixelFormat
-		if interval, exit := v4l2.GetFormatFrameInterval(fd, index, encoding, fmt.Width, fmt.Height); exit == nil {
+		encoding := pixFmt.PixelFormat
+		if interval, exit := v4l2.GetFormatFrameInterval(fd, index, encoding, pixFmt.Width, pixFmt.Height); exit == nil {
 			intervalCount += 1
 			intervals = append(intervals, interval.Interval.Max)
 		} else {

--- a/internal/driver/metadata.go
+++ b/internal/driver/metadata.go
@@ -144,6 +144,8 @@ func getDataFormat(d *usbdevice.Device) (interface{}, error) {
 		encoding := pixFmt.PixelFormat
 		if interval, err := v4l2.GetFormatFrameInterval(fd, index, encoding, pixFmt.Width, pixFmt.Height); err == nil {
 			intervalCount += 1
+			// this swaps the internally track frame interval (seconds per frame)
+			// to user-friendly frame rate (frames per second)
 			frameRates = append(frameRates, v4l2.Fract{
 				Denominator: interval.Interval.Max.Numerator,
 				Numerator:   interval.Interval.Max.Denominator,
@@ -250,6 +252,8 @@ func getSupportedFrameRateFormats(d *usbdevice.Device) (interface{}, error) {
 				index := uint32(intervalCount)
 				if interval, err := v4l2.GetFormatFrameInterval(fd, index, encoding, width, height); err == nil {
 					frameInfo.Rates = append(frameInfo.Rates, v4l2.Fract{
+						// this swaps the internally track frame interval (seconds per frame)
+						// to user-friendly frame rate (frames per second)
 						Denominator: interval.Interval.Max.Numerator,
 						Numerator:   interval.Interval.Max.Denominator,
 					})

--- a/internal/driver/metadata.go
+++ b/internal/driver/metadata.go
@@ -34,7 +34,7 @@ type DataFormat struct {
 	XferFunc     string
 	YcbcrEnc     string
 	Quantization string
-	FpsIntervals []uint32
+	FpsIntervals []v4l2.Fract
 }
 
 type CaptureMode struct {
@@ -137,14 +137,14 @@ func getDataFormat(d *usbdevice.Device) (interface{}, error) {
 	}
 	result.Quantization = quant
 	intervalCount := 0
-	var intervals []uint32
+	var intervals []v4l2.Fract
 	for {
 		fd := d.Fd()
 		index := uint32(intervalCount)
 		encoding := fmt.PixelFormat
 		if interval, exit := v4l2.GetFormatFrameInterval(fd, index, encoding, fmt.Width, fmt.Height); exit == nil {
-			intervals = append(intervals, interval.Interval.Max.Denominator)
 			intervalCount += 1
+			intervals = append(intervals, interval.Interval.Max)
 		} else {
 			break
 		}

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -6,6 +6,8 @@
 
 package driver
 
+import "github.com/vladimirvivien/go4vl/v4l2"
+
 type RTSPAuthRequest struct {
 	IP       string `json:"ip"`
 	User     string `json:"user"`
@@ -15,4 +17,17 @@ type RTSPAuthRequest struct {
 	ID       string `json:"id"`
 	Action   string `json:"action"`
 	Query    string `json:"query"`
+}
+
+type FrameInfo struct {
+	Index       uint32
+	FrameType   uint32
+	PixelFormat uint32
+	Height      uint32
+	Width       uint32
+	Rates       []v4l2.Fract
+}
+type FrameRateFormat struct {
+	Description string
+	FrameRates  []FrameInfo
 }


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Note, any commands executed need to include the query parameter `PathIndex` with the value set to the number representing the video path stream intended. For example: `http://localhost:59982/api/v3/url?PathIndex=0`. Also it is recommended to use the updated postman collection.
1. Execute the `FrameRateFormat` api to see supported fps values. This shows all fps values for each resolution for each type of encoding. This can be useful for determining the values to set the camera fps.
2. Execute the `DataFormat` api to see the supported fps values for the current video format and encoding.
3. Execute the `SetFrameRate` api and see no errors.The fps is represented in a time per frame format, meaning the denominator divided by the numerator yields the fps value. I did this to maintain consistency with the internal data structures. You can leave the numerator out completely, and the denominator will represent the fps value.
4. Execute the `GetFrameRate` api and see that the fps match.
5. Test the video stream and/or raw device stream to see if the changes apply. Certain video players seem to reset the fps value themselves, so it may not be viable to see the fps value of the /dev/video stream reflected in them.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->