### PR TITLE
feat: select stream for api commands

### DIFF
--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -821,7 +821,13 @@
 					"query": [
 						{
 							"key": "PathIndex",
-							"value": "{{path_index}}"
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
 						}
 					]
 				}
@@ -873,7 +879,13 @@
 					"query": [
 						{
 							"key": "PathIndex",
-							"value": "{{path_index}}"
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
 						}
 					]
 				},

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -1030,7 +1030,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/CameraStatus",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/CameraStatus?InputIndex=0",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -1046,7 +1046,11 @@
 					],
 					"query": [
 						{
-							"key": "InputIndex",
+                            "key": "InputIndex",
+                            "value": "0"
+						},
+                        {
+							"key": "PathIndex",
 							"value": "{{path_index}}",
 							"disabled": true
 						},

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -636,18 +636,6 @@
 						"name",
 						"{{camera_name}}",
 						"StreamingStatus"
-					],
-					"query": [
-						{
-							"key": "PathIndex",
-							"value": "{{path_index}}",
-							"disabled": true
-						},
-						{
-							"key": "StreamFormat",
-							"value": "{{stream_format}}",
-							"disabled": true
-						}
 					]
 				}
 			},

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -99,18 +99,6 @@
 						"name",
 						"{{camera_name}}",
 						"CameraInfo"
-					],
-					"query": [
-						{
-							"key": "PathIndex",
-							"value": "{{path_index}}",
-							"disabled": true
-						},
-						{
-							"key": "StreamFormat",
-							"value": "{{stream_format}}",
-							"disabled": true
-						}
 					]
 				}
 			},

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -993,18 +993,6 @@
 						"name",
 						"{{camera_name}}",
 						"StopStreaming"
-					],
-					"query": [
-						{
-							"key": "PathIndex",
-							"value": "{{path_index}}",
-							"disabled": true
-						},
-						{
-							"key": "StreamFormat",
-							"value": "{{stream_format}}",
-							"disabled": true
-						}
 					]
 				},
 				"description": "Test steps:\n\n1) Execute start streaming api with valid input and outputs\n2) Execute get stream status api and verify that \"IsStreaming\" set to true\n3) Execute stop stream api\n4) Execute get stream status api and verify that \"IsStreaming\" set to false\nNote: Camera shows green light in front when streaming started"

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "1cd1947d-95fa-456b-ae95-54b38b90723d",
+		"_postman_id": "12557ee1-fc0d-4e65-80f6-22633bc34747",
 		"name": "USB-Camera-Collection",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -99,6 +99,18 @@
 						"name",
 						"{{camera_name}}",
 						"CameraInfo"
+					],
+					"query": [
+						{
+							"key": "PathIndex",
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
+						}
 					]
 				}
 			},
@@ -148,6 +160,18 @@
 						"name",
 						"{{camera_name}}",
 						"VideoInputIndex"
+					],
+					"query": [
+						{
+							"key": "PathIndex",
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
+						}
 					]
 				}
 			},
@@ -197,6 +221,18 @@
 						"name",
 						"{{camera_name}}",
 						"ImageFormats"
+					],
+					"query": [
+						{
+							"key": "PathIndex",
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
+						}
 					]
 				}
 			},
@@ -233,7 +269,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/DataFormat?PathIndex={{path_index}}",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/DataFormat",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -250,7 +286,13 @@
 					"query": [
 						{
 							"key": "PathIndex",
-							"value": "{{path_index}}"
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
 						}
 					]
 				}
@@ -288,7 +330,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/FrameRateFormats?PathIndex={{path_index}}",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/FrameRateFormats",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -305,7 +347,13 @@
 					"query": [
 						{
 							"key": "PathIndex",
-							"value": "{{path_index}}"
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
 						}
 					]
 				}
@@ -356,6 +404,18 @@
 						"name",
 						"{{camera_name}}",
 						"CropCapability"
+					],
+					"query": [
+						{
+							"key": "PathIndex",
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
+						}
 					]
 				}
 			},
@@ -405,6 +465,18 @@
 						"name",
 						"{{camera_name}}",
 						"StreamingParam"
+					],
+					"query": [
+						{
+							"key": "PathIndex",
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
+						}
 					]
 				}
 			},
@@ -454,6 +526,18 @@
 						"name",
 						"{{camera_name}}",
 						"StreamURI"
+					],
+					"query": [
+						{
+							"key": "PathIndex",
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
+						}
 					]
 				}
 			},
@@ -503,6 +587,18 @@
 						"name",
 						"{{camera_name}}",
 						"GetCameraMetaData"
+					],
+					"query": [
+						{
+							"key": "PathIndex",
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
+						}
 					]
 				}
 			},
@@ -552,6 +648,18 @@
 						"name",
 						"{{camera_name}}",
 						"StreamingStatus"
+					],
+					"query": [
+						{
+							"key": "PathIndex",
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
+						}
 					]
 				}
 			},
@@ -588,7 +696,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/FrameRate?PathIndex={{path_index}}",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/FrameRate",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -605,7 +713,13 @@
 					"query": [
 						{
 							"key": "PathIndex",
-							"value": "{{path_index}}"
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
 						}
 					]
 				}
@@ -640,7 +754,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/FrameRate?PathIndex={{path_index}}",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/FrameRate",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -657,7 +771,13 @@
 					"query": [
 						{
 							"key": "PathIndex",
-							"value": "{{path_index}}"
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
 						}
 					]
 				},
@@ -814,6 +934,18 @@
 						"name",
 						"{{camera_name}}",
 						"StartStreaming"
+					],
+					"query": [
+						{
+							"key": "PathIndex",
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
+						}
 					]
 				},
 				"description": "Test steps:\n1) Execute start streaming api with valid input and outputs\n2) Execute get stream status api and verify that \"IsStreaming\" set to true \nNote: Camera shows green light in front when streaming started"
@@ -861,6 +993,18 @@
 						"name",
 						"{{camera_name}}",
 						"StopStreaming"
+					],
+					"query": [
+						{
+							"key": "PathIndex",
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
+						}
 					]
 				},
 				"description": "Test steps:\n\n1) Execute start streaming api with valid input and outputs\n2) Execute get stream status api and verify that \"IsStreaming\" set to true\n3) Execute stop stream api\n4) Execute get stream status api and verify that \"IsStreaming\" set to false\nNote: Camera shows green light in front when streaming started"
@@ -898,7 +1042,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/CameraStatus?InputIndex=0",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/CameraStatus",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -915,7 +1059,13 @@
 					"query": [
 						{
 							"key": "InputIndex",
-							"value": "0"
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
 						}
 					]
 				}
@@ -963,6 +1113,18 @@
 						"name",
 						"{{camera_name}}",
 						"StartStreaming"
+					],
+					"query": [
+						{
+							"key": "PathIndex",
+							"value": "{{path_index}}",
+							"disabled": true
+						},
+						{
+							"key": "StreamFormat",
+							"value": "{{stream_format}}",
+							"disabled": true
+						}
 					]
 				},
 				"description": "Test steps:\n\n1) Execute start streaming api with invalid input and outputs\n2) Execute get stream status api and verify that \"IsStreaming\" set to false and also see error in get stream status\n\nNote; Though it gives 200 it wont actually start streaming with invalid inputs this can be verified with get stream status api"

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -792,7 +792,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/PixelFormat?PathIndex={{path_index}}",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/PixelFormat",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -850,7 +850,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/PixelFormat?PathIndex={{path_index}}",
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/PixelFormat",
 					"protocol": "http",
 					"host": [
 						"{{command_host}}"
@@ -869,15 +869,10 @@
 							"key": "PathIndex",
 							"value": "{{path_index}}",
 							"disabled": true
-						},
-						{
-							"key": "StreamFormat",
-							"value": "{{stream_format}}",
-							"disabled": true
 						}
 					]
 				},
-				"description": "Test steps:\n\n1) Execute get pixel format api to get the current pixel format values for a video streaming path (PathIndex) of a camera  \n2) Execute set pixel format api with valid input for a camera's video streaming path\n\nNote: Valid input values are highly dependant on the camera."
+				"description": "Test steps:\n\n1) Execute get pixel format api to get the current pixel format values based on video streaming path (PathIndex) or stream format (RGB, Depth or Greyscale) of a camera  \n2) Execute set pixel format api with valid input for a camera's video streaming path\n\nNote: Valid input values are highly dependant on the camera."
 			},
 			"response": []
 		},

--- a/docs/USB_camera_env.postman_environment.json
+++ b/docs/USB_camera_env.postman_environment.json
@@ -43,6 +43,12 @@
 			"value": "0",
 			"type": "default",
 			"enabled": true
+		},
+        {
+			"key": "stream_format",
+			"value": "RGB",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -92,7 +92,5 @@ const (
 	PixFmtBYR2     = 844257602
 	PixFmtDepthZ16 = 540422490
 	PixFmtY8I      = 541669465
-	PixFmtY12I     = 28026201
-	PixFmtUYVY     = 1498831189
-	PixFmtGrey12I  = 1228026201
+	PixFmtY12I     = 1228026201
 )

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -34,6 +34,10 @@ const (
 	Width                           = "Width"
 	Height                          = "Height"
 	PixelFormat                     = "PixelFormat"
+	StreamFormat                    = "StreamFormat"
+	RGB                             = "RGB"
+	Greyscale                       = "Greyscale"
+	Depth                           = "Depth"
 
 	// API route specific to Device Service
 	ApiRefreshDevicePaths = "/refreshdevicepaths"

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -93,9 +93,6 @@ const (
 	PixFmtDepthZ16 = 540422490
 	PixFmtY8I      = 541669465
 	PixFmtY12I     = 28026201
-	// unsupported pixel formats
-	PixelFmtDepth  = 540422490
-	PixelFmtUYVY   = 1498831189
-	PixelFmtGrey8  = 541669465
-	PixelFmtGrey12 = 1228026201
+	PixFmtUYVY     = 1498831189
+	PixFmtGrey12I  = 1228026201
 )

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -93,4 +93,9 @@ const (
 	PixFmtDepthZ16 = 540422490
 	PixFmtY8I      = 541669465
 	PixFmtY12I     = 28026201
+	// unsupported pixel formats
+	PixelFmtDepth  = 540422490
+	PixelFmtUYVY   = 1498831189
+	PixelFmtGrey8  = 541669465
+	PixelFmtGrey12 = 1228026201
 )

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -233,16 +233,11 @@ func (dev *Device) GetPixelFormat(usbDevice *usbdevice.Device) (interface{}, err
 	// Since the go4vl library has limited pre-defined Pixel Format descriptions
 	// get the missing pixel format description using GetFormatDescriptions().
 	if result.PixelFormat == "" {
-		descs, err := usbDevice.GetFormatDescriptions()
+		desc, err := getPixFormatDesc(usbDevice, pixFmt.PixelFormat)
 		if err != nil {
 			return nil, err
 		}
-		for _, desc := range descs {
-			if pixFmt.PixelFormat == desc.PixelFormat {
-				result.PixelFormat = desc.Description
-				break
-			}
-		}
+		result.PixelFormat = desc
 	}
 
 	return result, nil

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -154,10 +154,12 @@ func (dev *Device) SetFrameRate(usbDevice *usbdevice.Device, frameRateNumerator 
 		return "", err
 	}
 	found := false
-	for _, frameRate := range dataFormat.(DataFormat).FrameRates {
-		if frameRateNumerator == frameRate.Numerator && frameRateDenominator == frameRate.Denominator {
-			found = true
-			break
+	for _, format := range dataFormat.(map[string]DataFormat) {
+		for _, frameRate := range format.FrameRates {
+			if frameRateNumerator == frameRate.Numerator && frameRateDenominator == frameRate.Denominator {
+				found = true
+				break
+			}
 		}
 	}
 	if !found {

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -50,15 +50,16 @@ type Device struct {
 }
 
 type streamingStatus struct {
-	IsStreaming        bool
-	Error              string
-	OutputFrames       string
-	InputFps           string
-	OutputFps          string
-	InputImageSize     string
-	OutputImageSize    string
-	OutputAspect       string
-	OutputVideoQuality string
+	TranscoderInputPath string
+	IsStreaming         bool
+	Error               string
+	OutputFrames        string
+	InputFps            string
+	OutputFps           string
+	InputImageSize      string
+	OutputImageSize     string
+	OutputAspect        string
+	OutputVideoQuality  string
 }
 
 func (dev *Device) StartStreaming() (<-chan string, <-chan error, error) {
@@ -99,6 +100,7 @@ func (dev *Device) updateTranscoderInputPath(fdPath string) error {
 		return errors.NewCommonEdgeX(errors.KindServerError,
 			fmt.Sprintf("failed to set new path for transcoder for device %s", dev.name), err)
 	}
+	dev.streamingStatus.TranscoderInputPath = fdPath
 	dev.lc.Debugf("Transcoder path succesfully set to %s", fdPath)
 	return nil
 }

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -92,6 +92,17 @@ func (dev *Device) StopStreaming() {
 	}
 }
 
+func (dev *Device) updateTranscoderInputPath(fdPath string) error {
+	trans := dev.transcoder
+	err := trans.SetInputPath(fdPath)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindServerError,
+			fmt.Sprintf("failed to set new path for transcoder for device %s", dev.name), err)
+	}
+	dev.lc.Debugf("Transcoder path succesfully set to %s", fdPath)
+	return nil
+}
+
 func (dev *Device) SetPixelFormat(usbDevice *usbdevice.Device, params interface{}) error {
 	// Get the current video pixel format to populate the fields missing from the input
 	v4l2PixelFormat, err := usbDevice.GetPixFormat()

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -329,7 +329,7 @@ func (d *Driver) ExecuteReadCommands(device *Device, req sdkModels.CommandReques
 
 	videoPath, err := d.getPathName(device, queryParams)
 	if err != nil {
-		return cv, err
+		return nil, err
 	}
 
 	cameraDevice, err := usbDevice.Open(videoPath)

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -41,6 +41,25 @@ import (
 var driver *Driver
 var once sync.Once
 
+var (
+	streamFormatTypeMap = map[uint32]string{
+		v4l2.PixelFmtRGB24: RGB,
+		v4l2.PixelFmtGrey:  Greyscale,
+		v4l2.PixelFmtYUYV:  RGB,
+		v4l2.PixelFmtMJPEG: RGB,
+		v4l2.PixelFmtJPEG:  RGB,
+		v4l2.PixelFmtMPEG:  RGB,
+		v4l2.PixelFmtH264:  RGB,
+		v4l2.PixelFmtMPEG4: RGB,
+		PixFmtBYR2:         RGB,
+		PixFmtUYVY:         Greyscale,
+		PixFmtY8I:          Greyscale,
+		PixFmtY12I:         Greyscale,
+		PixFmtGrey12I:      Greyscale,
+		PixFmtDepthZ16:     Depth,
+	}
+)
+
 const (
 	// rtspAuthSecretName defines the secretName used for storing RTSP credentials in the secret store.
 	rtspAuthSecretName string = "rtspauth"
@@ -513,7 +532,7 @@ func (d *Driver) ExecuteWriteCommands(device *Device, req sdkModels.CommandReque
 		}
 		d.lc.Infof("Device frame rate set to %s", fps)
 	case VideoSetPixelFormat:
-		params, edgexErr := params[i].ObjectValue()
+		params, edgexErr := param.ObjectValue()
 		if edgexErr != nil {
 			return errors.NewCommonEdgeXWrapper(edgexErr)
 		}
@@ -603,31 +622,12 @@ func getStreamFormatPath(path string, streamFormat string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	currentType, _ := getStreamFormatType(formatDescriptions[0].PixelFormat)
+	currentType := streamFormatTypeMap[formatDescriptions[0].PixelFormat]
 	if currentType == streamFormat {
 		return path, nil
 	} else {
 		return "", errors.NewCommonEdgeX(errors.KindInvalidId, "Provided stream format does not match current stream format type.", nil)
 	}
-}
-
-func getStreamFormatType(key uint32) (string, bool) {
-	streamFormatTypeMap := map[uint32]string{
-		v4l2.PixelFmtRGB24: RGB,
-		v4l2.PixelFmtGrey:  Greyscale,
-		v4l2.PixelFmtYUYV:  RGB,
-		v4l2.PixelFmtMJPEG: RGB,
-		v4l2.PixelFmtJPEG:  RGB,
-		v4l2.PixelFmtMPEG:  RGB,
-		v4l2.PixelFmtH264:  RGB,
-		v4l2.PixelFmtMPEG4: RGB,
-		PixelFmtDepth:      Depth,
-		PixelFmtUYVY:       Greyscale,
-		PixelFmtGrey8:      Greyscale,
-		PixelFmtGrey12:     Greyscale,
-	}
-	value, ok := streamFormatTypeMap[key]
-	return value, ok
 }
 
 // AddDevice is a callback function that is invoked

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -282,6 +282,12 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 
 		cv, err := d.ExecuteReadCommands(device, req, command)
 		if err != nil {
+			// flush query parameter for remaining reqs
+			for _, req := range reqs {
+				if _, ok := req.Attributes[UrlRawQuery]; ok {
+					req.Attributes[UrlRawQuery] = ""
+				}
+			}
 			return responses, err
 		}
 		if _, ok := req.Attributes[UrlRawQuery]; ok {
@@ -418,13 +424,17 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 
 		err := d.ExecuteWriteCommands(device, req, params[i], command)
 		if err != nil {
+			// flush query parameter for remaining reqs
+			for _, req := range reqs {
+				if _, ok := req.Attributes[UrlRawQuery]; ok {
+					req.Attributes[UrlRawQuery] = ""
+				}
+			}
 			return err
 		}
-		// flush query parameter
 		if _, ok := req.Attributes[UrlRawQuery]; ok {
 			req.Attributes[UrlRawQuery] = ""
 		}
-
 	}
 	return nil
 }

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -585,9 +585,8 @@ func (d *Driver) getPathName(device *Device, queryParams url.Values) (string, er
 			videoPath, err := getStreamFormatPath(path, streamFormat)
 			if err != nil {
 				continue
-			} else {
-				return videoPath, nil
 			}
+			return videoPath, nil
 		}
 		return "", errors.NewCommonEdgeX(errors.KindIOError, fmt.Sprintf("Invalid stream format for device %s.", device.name), nil)
 	}

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -350,7 +350,7 @@ func (d *Driver) ExecuteReadCommands(device *Device, req sdkModels.CommandReques
 		}
 		cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeObject, data)
 	case VideoGetFrameRate:
-		data, err = device.GetFrameRate(cameraDevice)
+		data, err = GetFrameRate(cameraDevice)
 		if err != nil {
 			return nil, errorWrapper.CommandError(command, err)
 		}
@@ -415,7 +415,7 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 					req.DeviceResourceName), nil)
 		}
 
-		err := d.ExecuteWriteCommands(device, req, i, params, command)
+		err := d.ExecuteWriteCommands(device, req, params[i], command)
 		if err != nil {
 			return err
 		}
@@ -428,7 +428,7 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 	return nil
 }
 
-func (d *Driver) ExecuteWriteCommands(device *Device, req sdkModels.CommandRequest, i int, params []*sdkModels.CommandValue, command interface{}) error {
+func (d *Driver) ExecuteWriteCommands(device *Device, req sdkModels.CommandRequest, param *sdkModels.CommandValue, command interface{}) error {
 	queryParams, edgexErr := getQueryParameters(req)
 	if edgexErr != nil {
 		return errors.NewCommonEdgeXWrapper(edgexErr)
@@ -452,7 +452,7 @@ func (d *Driver) ExecuteWriteCommands(device *Device, req sdkModels.CommandReque
 		if err != nil {
 			return err
 		}
-		options, edgexErr := params[i].ObjectValue()
+		options, edgexErr := param.ObjectValue()
 		if edgexErr != nil {
 			return errors.NewCommonEdgeXWrapper(edgexErr)
 		}
@@ -471,7 +471,7 @@ func (d *Driver) ExecuteWriteCommands(device *Device, req sdkModels.CommandReque
 		}
 		device.StopStreaming()
 	case VideoSetFrameRate:
-		frameRateParam, edgexErr := params[i].ObjectValue()
+		frameRateParam, edgexErr := param.ObjectValue()
 		if edgexErr != nil {
 			return errors.NewCommonEdgeXWrapper(edgexErr)
 		}

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -51,11 +51,10 @@ var (
 		v4l2.PixelFmtMPEG:  RGB,
 		v4l2.PixelFmtH264:  RGB,
 		v4l2.PixelFmtMPEG4: RGB,
+		v4l2.PixelFmtUYVY:  Greyscale,
 		PixFmtBYR2:         RGB,
-		PixFmtUYVY:         Greyscale,
 		PixFmtY8I:          Greyscale,
 		PixFmtY12I:         Greyscale,
-		PixFmtGrey12I:      Greyscale,
 		PixFmtDepthZ16:     Depth,
 	}
 )

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -203,10 +203,12 @@ func (d *Driver) Start() error {
 
 	for _, dev := range d.activeDevices {
 		if dev.autoStreaming {
+			dev.streamingStatus.TranscoderInputPath = dev.paths[0]
 			edgexErr := d.startStreaming(dev)
 			if edgexErr != nil {
 				d.lc.Errorf("failed to start video streaming for device %s, error: %s", dev.name, edgexErr)
 			}
+
 		}
 	}
 
@@ -483,6 +485,7 @@ func (d *Driver) ExecuteWriteCommands(device *Device, req sdkModels.CommandReque
 		if err != nil {
 			return err
 		}
+		device.streamingStatus.TranscoderInputPath = videoPath
 		options, edgexErr := param.ObjectValue()
 		if edgexErr != nil {
 			return errors.NewCommonEdgeXWrapper(edgexErr)
@@ -663,10 +666,12 @@ func (d *Driver) addDeviceInternal(deviceName string, protocols map[string]model
 	d.activeDevices[deviceName] = activeDevice
 	d.lc.Debugf("a new Device is added: %s", deviceName)
 	if activeDevice.autoStreaming {
+		activeDevice.streamingStatus.TranscoderInputPath = paths[0]
 		edgexErr = d.startStreaming(activeDevice)
 		if edgexErr != nil {
 			return nil, errors.NewCommonEdgeXWrapper(edgexErr)
 		}
+
 	}
 	return activeDevice, nil
 }
@@ -858,7 +863,7 @@ func (d *Driver) newDevice(name string, protocols map[string]models.ProtocolProp
 	}
 	trans.MediaFile().SetOutputFormat(RtspUriScheme)
 
-	autoStreaming := false
+	autoStreaming := true
 	autoStreamingStr, edgexErr := d.getProtocolProperty(protocols, UsbProtocol, AutoStreaming)
 	if edgexErr != nil {
 		d.lc.Warnf("Protocol property %s not found. Use default value: %v", AutoStreaming, autoStreaming)

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -30,7 +30,7 @@ func createDriverWithMockService() (*Driver, *sdkMocks.DeviceServiceSDK) {
 func NewDriver() *Driver {
 	return &Driver{
 		activeDevices: map[string]*Device{
-			"testDeviceRealsense": &Device{
+			"testDeviceRealsense": {
 				paths: []string{
 					"/dev/video0",
 					"/dev/video2",

--- a/internal/driver/ffmpeg.go
+++ b/internal/driver/ffmpeg.go
@@ -127,7 +127,7 @@ func setupFFmpegOptions(dev *Device, opts interface{}, attr map[string]interface
 
 	// obtain default FFmpeg options defined in resource attributes
 	for name, value := range attr {
-		if name == SetFunction {
+		if name == SetFunction || name == UrlRawQuery {
 			continue
 		}
 		optName := strings.ReplaceAll(name, "default", "")

--- a/internal/driver/metadata.go
+++ b/internal/driver/metadata.go
@@ -107,7 +107,7 @@ func getDataFormat(d *usbdevice.Device) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	pixDescription, _ := completeFormatMap(pixFmt.PixelFormat)
+	pixDescription, _ := getCompleteFormatMapEntry(pixFmt.PixelFormat)
 	dataFormat := DataFormat{}
 	dataFormat.Height = pixFmt.Height
 	dataFormat.Width = pixFmt.Width
@@ -215,7 +215,7 @@ func getImageFormats(d *usbdevice.Device) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		pixDescription, _ := completeFormatMap(desc.PixelFormat)
+		pixDescription, _ := getCompleteFormatMapEntry(desc.PixelFormat)
 		r.ImageFormats = append(r.ImageFormats, ImageFormat{
 			Index:       desc.Index,
 			BufType:     desc.StreamType,
@@ -244,7 +244,7 @@ func getSupportedFrameRateFormats(d *usbdevice.Device) (interface{}, error) {
 	var r result
 	for _, desc := range descs {
 		var format FrameRateFormat
-		format.Description, _ = completeFormatMap(desc.PixelFormat)
+		format.Description, _ = getCompleteFormatMapEntry(desc.PixelFormat)
 		fss, err := v4l2.GetFormatFrameSizes(d.Fd(), desc.PixelFormat)
 		if err != nil {
 			return nil, err
@@ -296,4 +296,20 @@ func GetFrameRate(d *usbdevice.Device) (interface{}, error) {
 	result := make(map[string]v4l2.Fract)
 	result[d.Name()] = fps
 	return result, nil
+}
+
+func getCompleteFormatMapEntry(key uint32) (string, bool) {
+	unsupported := map[uint32]string{
+		PixelFmtDepth:  PixelFmtDepthDesc,
+		PixelFmtUYVY:   PixelFmtUYVYDesc,
+		PixelFmtGrey8:  PixelFmtGrey8Desc,
+		PixelFmtGrey12: PixelFmtGrey12Desc,
+	}
+	if value, ok := unsupported[key]; ok {
+		return value, ok
+	}
+	if value, ok := v4l2.PixelFormats[key]; ok {
+		return value, ok
+	}
+	return "", false
 }

--- a/internal/driver/metadata.go
+++ b/internal/driver/metadata.go
@@ -107,7 +107,7 @@ func getDataFormat(d *usbdevice.Device) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	pixDescription := getCompleteFormatMapEntry(d, pixFmt.PixelFormat)
+	pixDescription, _ := getPixFormatDesc(d, pixFmt.PixelFormat)
 	dataFormat := DataFormat{
 		Height:                 pixFmt.Height,
 		Width:                  pixFmt.Width,
@@ -216,7 +216,7 @@ func getImageFormats(d *usbdevice.Device) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		pixDescription := getCompleteFormatMapEntry(d, desc.PixelFormat)
+		pixDescription, _ := getPixFormatDesc(d, desc.PixelFormat)
 		r.ImageFormats = append(r.ImageFormats, ImageFormat{
 			Index:       desc.Index,
 			BufType:     desc.StreamType,
@@ -245,7 +245,7 @@ func getSupportedFrameRateFormats(d *usbdevice.Device) (interface{}, error) {
 	var r result
 	for _, desc := range descs {
 		var format FrameRateFormat
-		format.Description = getCompleteFormatMapEntry(d, desc.PixelFormat)
+		format.Description, _ = getPixFormatDesc(d, desc.PixelFormat)
 		fss, err := v4l2.GetFormatFrameSizes(d.Fd(), desc.PixelFormat)
 		if err != nil {
 			return nil, err
@@ -299,15 +299,15 @@ func GetFrameRate(d *usbdevice.Device) (interface{}, error) {
 	return result, nil
 }
 
-func getCompleteFormatMapEntry(usbDevice *usbdevice.Device, pixFmt uint32) string {
+func getPixFormatDesc(usbDevice *usbdevice.Device, pixFmt uint32) (string, error) {
 	descs, err := usbDevice.GetFormatDescriptions()
 	if err != nil {
-		return ""
+		return "", err
 	}
 	for _, desc := range descs {
 		if pixFmt == desc.PixelFormat {
-			return desc.Description
+			return desc.Description, nil
 		}
 	}
-	return ""
+	return "", nil
 }

--- a/internal/driver/metadata.go
+++ b/internal/driver/metadata.go
@@ -107,12 +107,7 @@ func getDataFormat(d *usbdevice.Device) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	var pixDescription string
-	if pixFmt.PixelFormat == 540422490 {
-		pixDescription = PixelFmtDepthDesc
-	} else {
-		pixDescription = v4l2.PixelFormats[pixFmt.PixelFormat]
-	}
+	pixDescription, _ := completeFormatMap(pixFmt.PixelFormat)
 	dataFormat := DataFormat{}
 	dataFormat.Height = pixFmt.Height
 	dataFormat.Width = pixFmt.Width
@@ -220,12 +215,7 @@ func getImageFormats(d *usbdevice.Device) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		var pixDescription string
-		if desc.PixelFormat == 540422490 {
-			pixDescription = PixelFmtDepthDesc
-		} else {
-			pixDescription = desc.Description
-		}
+		pixDescription, _ := completeFormatMap(desc.PixelFormat)
 		r.ImageFormats = append(r.ImageFormats, ImageFormat{
 			Index:       desc.Index,
 			BufType:     desc.StreamType,
@@ -254,7 +244,7 @@ func getSupportedFrameRateFormats(d *usbdevice.Device) (interface{}, error) {
 	var r result
 	for _, desc := range descs {
 		var format FrameRateFormat
-		format.Description = desc.String()
+		format.Description, _ = completeFormatMap(desc.PixelFormat)
 		fss, err := v4l2.GetFormatFrameSizes(d.Fd(), desc.PixelFormat)
 		if err != nil {
 			return nil, err

--- a/internal/driver/metadata.go
+++ b/internal/driver/metadata.go
@@ -24,7 +24,6 @@ type Capability struct {
 }
 
 type DataFormat struct {
-	Path                   string
 	Width                  uint32
 	Height                 uint32
 	PixelFormat            uint32

--- a/internal/driver/metadata.go
+++ b/internal/driver/metadata.go
@@ -24,18 +24,19 @@ type Capability struct {
 }
 
 type DataFormat struct {
-	Path         string
-	Width        uint32
-	Height       uint32
-	PixelFormat  string
-	Field        string
-	BytesPerLine uint32
-	SizeImage    uint32
-	Colorspace   string
-	XferFunc     string
-	YcbcrEnc     string
-	Quantization string
-	FrameRates   []v4l2.Fract
+	Path                   string
+	Width                  uint32
+	Height                 uint32
+	PixelFormat            uint32
+	PixelFormatDescription string
+	Field                  string
+	BytesPerLine           uint32
+	SizeImage              uint32
+	Colorspace             string
+	XferFunc               string
+	YcbcrEnc               string
+	Quantization           string
+	FrameRates             []v4l2.Fract
 }
 
 type CaptureMode struct {
@@ -60,7 +61,7 @@ type ImageFormat struct {
 	BufType     v4l2.BufType
 	Flags       v4l2.FmtDescFlag
 	Description string
-	PixelFormat string
+	PixelFormat uint32
 	MbusCode    uint32
 	FrameSizes  []v4l2.FrameSizeEnum
 }
@@ -106,11 +107,17 @@ func getDataFormat(d *usbdevice.Device) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	var pixDescription string
+	if pixFmt.PixelFormat == 540422490 {
+		pixDescription = PixelFmtDepthDesc
+	} else {
+		pixDescription = v4l2.PixelFormats[pixFmt.PixelFormat]
+	}
 	dataFormat := DataFormat{}
 	dataFormat.Height = pixFmt.Height
 	dataFormat.Width = pixFmt.Width
-	dataFormat.PixelFormat = v4l2.PixelFormats[pixFmt.PixelFormat]
+	dataFormat.PixelFormat = pixFmt.PixelFormat
+	dataFormat.PixelFormatDescription = pixDescription
 	dataFormat.Field = v4l2.Fields[pixFmt.Field]
 	dataFormat.BytesPerLine = pixFmt.BytesPerLine
 	dataFormat.SizeImage = pixFmt.SizeImage
@@ -213,12 +220,18 @@ func getImageFormats(d *usbdevice.Device) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
+		var pixDescription string
+		if desc.PixelFormat == 540422490 {
+			pixDescription = PixelFmtDepthDesc
+		} else {
+			pixDescription = desc.Description
+		}
 		r.ImageFormats = append(r.ImageFormats, ImageFormat{
 			Index:       desc.Index,
 			BufType:     desc.StreamType,
 			Flags:       desc.Flags,
-			Description: desc.Description,
-			PixelFormat: v4l2.PixelFormats[desc.PixelFormat],
+			Description: pixDescription,
+			PixelFormat: desc.PixelFormat,
 			MbusCode:    desc.MBusCode,
 			FrameSizes:  fss,
 		})

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -19,6 +19,7 @@ type RTSPAuthRequest struct {
 	Query    string `json:"query"`
 }
 
+
 type FrameInfo struct {
 	Index       uint32
 	FrameType   uint32

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -19,7 +19,6 @@ type RTSPAuthRequest struct {
 	Query    string `json:"query"`
 }
 
-
 type FrameInfo struct {
 	Index       uint32
 	FrameType   uint32
@@ -28,6 +27,7 @@ type FrameInfo struct {
 	Width       uint32
 	Rates       []v4l2.Fract
 }
+
 type FrameRateFormat struct {
 	Description string
 	FrameRates  []FrameInfo


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) I've only added device level functionality
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Execute each command with no query parameters and see status code 200.
2. Execute each command with the `PathIndex` set to the appropriate value. For standard usb cameras, this can only be 0, and for RealSense cameras this can be 0, 1, or 2. If the index is outside of that range, it will send an error.
3. Execute each command with the `StreamFormat` set to the appropriate value. For standard usb cameras, this can only be "RGB", and for RealSense cameras this can be "RGB", "Greyscale" or "Depth". If the value is not supported, it will send an error.
4. For realsense, start streaming for each index and check that the stream is working (using vlc or mplayer) and there are no errors. Also make sure that the streams are accurate, ie rgb shows rgb, etc. Make sure to stop streaming after checking the stream.
Note: Some commands will return the "/dev/video" stream. Make sure that matches the stream that you supplied in the query parameter.
Note: The stop streaming command does not need one of these query parameters.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->