### PR TITLE
refactor: use PatchDevice calls instead of UpdateDevice

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -936,6 +936,7 @@ func (d *Driver) isVideoCaptureDevice(path string) bool {
 }
 
 func (d *Driver) updateDevicePaths(device models.Device) {
+	oldPaths := device.Protocols[UsbProtocol][Paths]
 	var init []string
 	device.Protocols[UsbProtocol][Paths] = init
 	allDevices, _ := usbDevice.GetAllDevicePaths()
@@ -951,8 +952,14 @@ func (d *Driver) updateDevicePaths(device models.Device) {
 			}
 		}
 	}
-	if err := d.ds.UpdateDevice(device); err != nil {
-		d.lc.Errorf("failed to update paths for the device %s", device.Name)
+
+	if !slicesAreEqual(d.lc, device.Protocols[UsbProtocol][Paths], oldPaths) {
+		if err := d.ds.PatchDevice(dtos.UpdateDevice{
+			Name:      &device.Name,
+			Protocols: dtos.FromProtocolModelsToDTOs(device.Protocols),
+		}); err != nil {
+			d.lc.Errorf("failed to update paths for the device %s", device.Name)
+		}
 	}
 }
 

--- a/internal/driver/helper.go
+++ b/internal/driver/helper.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2022 Intel Corporation
+// Copyright (C) 2022-2023 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,6 +8,7 @@ package driver
 
 import (
 	"fmt"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"regexp"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
@@ -30,4 +31,33 @@ func (e EdgeXErrorWrapper) CommandError(command string, err error) errors.EdgeX 
 // redact removes all instances of basic auth (ie. rtsp://username:password@server) from a url
 func redact(val string) string {
 	return userPassRegex.ReplaceAllString(val, redactedStr)
+}
+
+// slicesAreEqual returns true if two []string slices contain the same elements in the same exact order. It will return
+// false if any elements are not equal, and will return false if the elements are in different order.
+func slicesAreEqual(lc logger.LoggingClient, a, b any) bool {
+	if a == nil && b == nil {
+		return true
+	}
+
+	aSlice, ok := a.([]string)
+	if !ok {
+		lc.Errorf("Expected argument 'a' to slicesAreEqual to be a slice of strings, but got type %T", a)
+		return false
+	}
+	bSlice, ok := b.([]string)
+	if !ok {
+		lc.Errorf("Expected argument 'b' to slicesAreEqual to be a slice of strings, but got type %T", b)
+		return false
+	}
+
+	if len(aSlice) != len(bSlice) {
+		return false
+	}
+	for i, val := range aSlice {
+		if val != bSlice[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/driver/helper_test.go
+++ b/internal/driver/helper_test.go
@@ -1,0 +1,84 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package driver
+
+import (
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSlicesAreEqual(t *testing.T) {
+	tests := []struct {
+		name   string
+		a      any
+		b      any
+		expect bool
+	}{
+		{
+			name:   "both nil",
+			a:      nil,
+			b:      nil,
+			expect: true,
+		},
+		{
+			name:   "b nil",
+			a:      []string{"a"},
+			b:      nil,
+			expect: false,
+		},
+		{
+			name:   "a nil",
+			a:      nil,
+			b:      []string{"b"},
+			expect: false,
+		},
+		{
+			name:   "a nil",
+			a:      nil,
+			b:      []string{"b"},
+			expect: false,
+		},
+		{
+			name:   "different items",
+			a:      []string{"a", "1"},
+			b:      []string{"b", "2"},
+			expect: false,
+		},
+		{
+			name:   "same items, same order",
+			a:      []string{"test", "me"},
+			b:      []string{"test", "me"},
+			expect: true,
+		},
+		{
+			name:   "same items, different order",
+			a:      []string{"me", "test"},
+			b:      []string{"test", "me"},
+			expect: false,
+		},
+		{
+			name:   "different amount",
+			a:      []string{"1", "2", "3"},
+			b:      []string{"1", "2", "3", "4"},
+			expect: false,
+		},
+		{
+			name:   "wrong type",
+			a:      []int{1, 2, 3},
+			b:      []int{1, 2, 3},
+			expect: false,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			actual := slicesAreEqual(logger.MockLogger{}, test.a, test.b)
+			assert.Equal(t, test.expect, actual)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [N/A] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

- Run device service as normal and add usb cameras
- Change the /dev/videoX order of cameras by unplugging re-plugging (may require multiple devices)
- Re-run discovery, or RefreshExistingDevicePaths
- Ensure updated device paths are present in core-metadata
- Run unit tests

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->