### PR TITLE
feat: ability to disable RTSP server on startup via configuration

### DIFF
--- a/cmd/res/configuration.yaml
+++ b/cmd/res/configuration.yaml
@@ -38,6 +38,7 @@ Device:
     Interval: "1h"
 
 Driver:
+  EnableRtspServer: "true"
   RtspServerHostName: "localhost"
   RtspTcpPort: "8554"
   RtspAuthenticationServer: "localhost:8000"

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -16,6 +16,8 @@ const (
 	AutoStreaming                   = "AutoStreaming"
 	InputIndex                      = "InputIndex"
 	UrlRawQuery                     = "urlRawQuery"
+	EnableRtspServer                = "EnableRtspServer"
+	RtspServerCmd                   = "./rtsp-simple-server"
 	RtspServerHostName              = "RtspServerHostName"
 	DefaultRtspServerHostName       = "localhost"
 	RtspTcpPort                     = "RtspTcpPort"

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -106,7 +106,7 @@ func (d *Driver) Initialize(sdk interfaces.DeviceServiceSDK) error {
 		_, err := os.Stat(RtspServerCmd)
 		if err != nil {
 			if os.IsNotExist(err) {
-				return fmt.Errorf("%s file canont be found: %s", RtspServerCmd, err.Error())
+				return fmt.Errorf("%s file cannot be found: %s", RtspServerCmd, err.Error())
 			}
 		}
 		rtspProc := exec.Command(RtspServerCmd)

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -306,71 +306,79 @@ func (d *Driver) ExecuteReadCommands(device *Device, req sdkModels.CommandReques
 	case MetadataDeviceCapability:
 		data, err = getCapability(cameraDevice)
 		if err != nil {
-			return cv, errorWrapper.CommandError(command, err)
+			return nil, errorWrapper.CommandError(command, err)
 		}
 		cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeObject, data)
 	case MetadataCurrentVideoInput:
 		data, err = cameraDevice.GetVideoInputIndex()
 		if err != nil {
-			return cv, errorWrapper.CommandError(command, err)
+			return nil, errorWrapper.CommandError(command, err)
 		}
 		cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeInt32, data)
 	case MetadataCameraStatus:
 		index := queryParams.Get(InputIndex)
 		if len(index) == 0 {
-			return cv, fmt.Errorf("mandatory query parameter %s not found", InputIndex)
+			return nil, fmt.Errorf("mandatory query parameter %s not found", InputIndex)
 		}
 		data, err = getInputStatus(cameraDevice, index)
 		if err != nil {
-			return cv, errorWrapper.CommandError(command, err)
+			return nil, errorWrapper.CommandError(command, err)
 		}
 		cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeUint32, data)
 	case MetadataImageFormats:
 		data, err = getImageFormats(cameraDevice)
 		if err != nil {
-			return cv, errorWrapper.CommandError(command, err)
+			return nil, errorWrapper.CommandError(command, err)
 		}
 		cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeObject, data)
 	case MetadataFrameRateFormats:
 		data, err = getSupportedFrameRateFormats(cameraDevice)
 		if err != nil {
-			return cv, errorWrapper.CommandError(command, err)
+			return nil, errorWrapper.CommandError(command, err)
 		}
 		cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeObject, data)
 	case VideoGetFrameRate:
 		data, err = device.GetFrameRate(cameraDevice)
 		if err != nil {
-			return cv, errorWrapper.CommandError(command, err)
+			return nil, errorWrapper.CommandError(command, err)
 		}
 		cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeObject, data)
 	case MetadataDataFormat:
 		data, err = getDataFormat(cameraDevice)
 		if err != nil {
-			return cv, errorWrapper.CommandError(command, err)
+			return nil, errorWrapper.CommandError(command, err)
 		}
 		cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeObject, data)
 	case MetadataCroppingAbility:
 		data, err = getCropInfo(cameraDevice)
 		if err != nil {
-			return cv, errorWrapper.CommandError(command, err)
+			return nil, errorWrapper.CommandError(command, err)
 		}
 		cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeObject, data)
 	case MetadataStreamingParameters:
 		data, err = getStreamingParameters(cameraDevice)
 		if err != nil {
-			return cv, errorWrapper.CommandError(command, err)
+			return nil, errorWrapper.CommandError(command, err)
 		}
 		cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeObject, data)
 	case VideoStreamUri:
+		if !d.enableRtspServer {
+			return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf(
+				"rtsp server is not enabled, cannot get stream URI for device %s", device.name), nil)
+		}
 		cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, req.Type, device.rtspUri)
 
 	case VideoStreamingStatus:
+		if !d.enableRtspServer {
+			return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf(
+				"rtsp server is not enabled, cannot get streaming status for device %s", device.name), nil)
+		}
 		cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeObject, device.streamingStatus)
 	default:
-		return cv, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("unsupported command %s", command), nil)
+		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("unsupported command %s", command), nil)
 	}
 	if err != nil {
-		return cv, errors.NewCommonEdgeX(errors.KindServerError, "failed to create CommandValue", err)
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to create CommandValue", err)
 	}
 	return cv, nil
 }

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -141,7 +141,7 @@ func (d *Driver) Initialize(sdk interfaces.DeviceServiceSDK) error {
 		} else if os.IsPermission(err) {
 			return fmt.Errorf("permission denied for %s: %s", RtspServerCmd, err.Error())
 		} else {
-			return fmt.Errorf("failed to validate file %s: %s", RtspServerCmd, err.Error())
+			return fmt.Errorf("unknown error occurred while checking for rtsp-server binary file %s: %s", RtspServerCmd, err.Error())
 		}
 	}
 
@@ -195,7 +195,6 @@ func (d *Driver) Start() error {
 
 func (d *Driver) StartRTSPCredentialServer() {
 	d.lc.Infof("Starting rtsp authentication server on %s", d.rtspAuthenticationServerUri)
-	defer d.wg.Done()
 
 	router := mux.NewRouter()
 	router.HandleFunc("/rtspauth", d.RTSPCredentialsHandler)


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)N/A
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
N/A

## Testing Instructions
1. run `make test`
2.  start up edgex using edgex-compose `make run no-secty`
3. build device-usb-camera `make build`
4. enable/ disable  EnableRtspServer in canfiguration.yml
5. verify Rtsp server starts and does not start when enabled/disabled

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->