### PR TITLE
feat: implement get/set pixel format commands.

### DIFF
--- a/cmd/res/profiles/general.usb.camera.yaml
+++ b/cmd/res/profiles/general.usb.camera.yaml
@@ -95,6 +95,14 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "RW"
+  - name: "PixelFormat"
+    description: "Set and get the pixel format, height and width"
+    attributes:
+      getFunction: "VIDEO_GET_PIXELFORMAT"
+      setFunction: "VIDEO_SET_PIXELFORMAT"
+    properties:
+      valueType: "Object"
+      readWrite: "RW"
   - name: "StreamURI"
     description: "Get video-streaming URI."
     attributes:

--- a/cmd/res/profiles/general.usb.camera.yaml
+++ b/cmd/res/profiles/general.usb.camera.yaml
@@ -88,7 +88,7 @@ deviceResources:
       readWrite: "W"
       defaultValue: "false"
   - name: "FrameRate"
-    description: "Set and get the stream frame rate"
+    description: "Get and set the stream frame rate"
     attributes: 
         getFunction: "VIDEO_GET_FRAMERATE"
         setFunction: "VIDEO_SET_FRAMERATE"
@@ -96,7 +96,7 @@ deviceResources:
       valueType: "Object"
       readWrite: "RW"
   - name: "PixelFormat"
-    description: "Set and get the video pixel format"
+    description: "Get and set the video pixel format"
     attributes:
       getFunction: "VIDEO_GET_PIXELFORMAT"
       setFunction: "VIDEO_SET_PIXELFORMAT"

--- a/cmd/res/profiles/general.usb.camera.yaml
+++ b/cmd/res/profiles/general.usb.camera.yaml
@@ -96,7 +96,7 @@ deviceResources:
       valueType: "Object"
       readWrite: "RW"
   - name: "PixelFormat"
-    description: "Set and get the pixel format, height and width"
+    description: "Set and get the video pixel format"
     attributes:
       getFunction: "VIDEO_GET_PIXELFORMAT"
       setFunction: "VIDEO_SET_PIXELFORMAT"

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -740,7 +740,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\"PixelFormat\": {\n        \"Width\":\"640\",\n        \"Height\":\"480\",\n        \"PixelFormat\": \"RGB\",\n        \"Field\": \"ANY\",\n        \"BytesPerLine\":\"7\",\n        \"SizeImage\": \"100\",\n        \"Colorspace\":\"DEFAULT\"\n    }\n}",
+					"raw": "{\n\"PixelFormat\": {\n        \"Width\":\"640\",\n        \"Height\":\"480\",\n        \"PixelFormat\": \"YUYV\"\n   }\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -51,7 +51,7 @@
 						"{{device_service_name}}"
 					]
 				},
-				"description": "To get all onvif devices change {device_service_name} environment varibale to device-onvif-camera"
+				"description": "To get all USB devices change {device_service_name} environment varibale to device-usb-camera"
 			},
 			"response": []
 		},

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -666,6 +666,114 @@
 			"response": []
 		},
 		{
+			"name": "Get Pixel Format",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"  pm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/PixelFormat?PathIndex={{path_index}}",
+					"protocol": "http",
+					"host": [
+						"{{command_host}}"
+					],
+					"port": "{{command_port}}",
+					"path": [
+						"api",
+						"v3",
+						"device",
+						"name",
+						"{{camera_name}}",
+						"PixelFormat"
+					],
+					"query": [
+						{
+							"key": "PathIndex",
+							"value": "{{path_index}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Set Pixel Format",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"  pm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "PUT",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\"PixelFormat\": {\n        \"Width\":\"640\",\n        \"Height\":\"480\",\n        \"PixelFormat\": \"RGB\",\n        \"Field\": \"ANY\",\n        \"BytesPerLine\":\"7\",\n        \"SizeImage\": \"100\",\n        \"Colorspace\":\"DEFAULT\"\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{command_host}}:{{command_port}}/api/v3/device/name/{{camera_name}}/PixelFormat?PathIndex={{path_index}}",
+					"protocol": "http",
+					"host": [
+						"{{command_host}}"
+					],
+					"port": "{{command_port}}",
+					"path": [
+						"api",
+						"v3",
+						"device",
+						"name",
+						"{{camera_name}}",
+						"PixelFormat"
+					],
+					"query": [
+						{
+							"key": "PathIndex",
+							"value": "{{path_index}}"
+						}
+					]
+				},
+				"description": "Test steps:\n\n1) Execute get pixel format api to get the current pixel format values  \n2) Execute set pixel format api with valid input\n\nNote, valid input values and highly dependant on the camera."
+			},
+			"response": []
+		},
+		{
 			"name": "Start streaming with valid input and output",
 			"event": [
 				{

--- a/docs/USB-Camera-Collection.postman_collection.json
+++ b/docs/USB-Camera-Collection.postman_collection.json
@@ -769,7 +769,7 @@
 						}
 					]
 				},
-				"description": "Test steps:\n\n1) Execute get pixel format api to get the current pixel format values  \n2) Execute set pixel format api with valid input\n\nNote, valid input values and highly dependant on the camera."
+				"description": "Test steps:\n\n1) Execute get pixel format api to get the current pixel format values for a video streaming path (PathIndex) of a camera  \n2) Execute set pixel format api with valid input for a camera's video streaming path\n\nNote: Valid input values are highly dependant on the camera."
 			},
 			"response": []
 		},

--- a/docs/USB_camera_env.postman_environment.json
+++ b/docs/USB_camera_env.postman_environment.json
@@ -33,18 +33,6 @@
 			"enabled": true
 		},
 		{
-			"key": "device_onvif_service_port",
-			"value": "59985",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "device_onvif_service_host",
-			"value": "localhost",
-			"type": "default",
-			"enabled": true
-		},
-		{
 			"key": "device_service_name",
 			"value": "device-usb-camera",
 			"type": "default",

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -31,11 +31,7 @@ const (
 	PathIndex                       = "PathIndex"
 	PixFmtWidth                     = "Width"
 	PixFmtHeight                    = "Height"
-	PixFmtField                     = "Field"
 	PixFmtPixFmt                    = "PixelFormat"
-	PixFmtBytesPerLine              = "BytesPerLine"
-	PixFmtSizeImage                 = "SizeImage"
-	PixFmtColorspace                = "Colorspace"
 
 	// API route specific to Device Service
 	ApiRefreshDevicePaths = "/refreshdevicepaths"

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -31,7 +31,7 @@ const (
 	PathIndex                       = "PathIndex"
 	Width                           = "Width"
 	Height                          = "Height"
-	PixFormat                       = "PixelFormat"
+	PixelFormat                     = "PixelFormat"
 
 	// API route specific to Device Service
 	ApiRefreshDevicePaths = "/refreshdevicepaths"
@@ -83,8 +83,8 @@ const (
 	UdevV4lProduct  = "ID_V4L_PRODUCT"
 
 	// Pixel Formats not supported by go4vl pre-defined pixel format definitions
-	BYR2PixFmt     = 844257602
-	DepthZ16PixFmt = 540422490
-	Y8IPixFmt      = 541669465
-	Y12IPixFmt     = 28026201
+	PixFmtBYR2     = 844257602
+	PixFmtDepthZ16 = 540422490
+	PixFmtY8I      = 541669465
+	PixFmtY12I     = 28026201
 )

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -29,6 +29,13 @@ const (
 	FrameRateValueDenominator       = "FrameRateValueDenominator"
 	FrameRateValueNumerator         = "FrameRateValueNumerator"
 	PathIndex                       = "PathIndex"
+	PixFmtWidth                     = "Width"
+	PixFmtHeight                    = "Height"
+	PixFmtField                     = "Field"
+	PixFmtPixFmt                    = "PixelFormat"
+	PixFmtBytesPerLine              = "BytesPerLine"
+	PixFmtSizeImage                 = "SizeImage"
+	PixFmtColorspace                = "Colorspace"
 
 	// API route specific to Device Service
 	ApiRefreshDevicePaths = "/refreshdevicepaths"

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -29,9 +29,9 @@ const (
 	FrameRateValueDenominator       = "FrameRateValueDenominator"
 	FrameRateValueNumerator         = "FrameRateValueNumerator"
 	PathIndex                       = "PathIndex"
-	PixFmtWidth                     = "Width"
-	PixFmtHeight                    = "Height"
-	PixFmtPixFmt                    = "PixelFormat"
+	Width                           = "Width"
+	Height                          = "Height"
+	PixFormat                       = "PixelFormat"
 
 	// API route specific to Device Service
 	ApiRefreshDevicePaths = "/refreshdevicepaths"
@@ -81,4 +81,10 @@ const (
 	UdevSerialShort = "ID_SERIAL_SHORT"
 	UdevSerial      = "ID_SERIAL"
 	UdevV4lProduct  = "ID_V4L_PRODUCT"
+
+	// Pixel Formats not supported by go4vl pre-defined pixel format definitions
+	BYR2PixFmt     = 844257602
+	DepthZ16PixFmt = 540422490
+	Y8IPixFmt      = 541669465
+	Y12IPixFmt     = 28026201
 )

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -53,6 +53,8 @@ const (
 	VideoStreamingStatus        = "VIDEO_STREAMING_STATUS"
 	VideoGetFrameRate           = "VIDEO_GET_FRAMERATE"
 	VideoSetFrameRate           = "VIDEO_SET_FRAMERATE"
+	VideoGetPixelFormat         = "VIDEO_GET_PIXELFORMAT"
+	VideoSetPixelFormat         = "VIDEO_SET_PIXELFORMAT"
 
 	// FFmpeg options
 	FFmpegFrames      = "-frames:d"

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -92,7 +93,104 @@ func (dev *Device) StopStreaming() {
 }
 
 func (dev *Device) SetPixelFormat(usbDevice *usbdevice.Device, params interface{}) (string, error) {
-	return "", nil
+	v4l2PixelFormat, err := usbDevice.GetPixFormat()
+	if err != nil {
+		dev.lc.Errorf("Could not get pixel format, error: %s", err)
+		return "", err
+	}
+
+	var width uint64
+	widthValue, ok := params.(map[string]interface{})[PixFmtWidth]
+	if !ok {
+		width = uint64(v4l2PixelFormat.Width)
+	} else {
+		width, err = strconv.ParseUint(widthValue.(string), 0, 32)
+		if err != nil {
+			return "", errors.NewCommonEdgeXWrapper(nil)
+		}
+	}
+
+	var height uint64
+	heightValue, ok := params.(map[string]interface{})[PixFmtHeight]
+	if !ok {
+		height = uint64(v4l2PixelFormat.Height)
+	} else {
+		height, err = strconv.ParseUint(heightValue.(string), 0, 32)
+		if err != nil {
+			return "", errors.NewCommonEdgeXWrapper(nil)
+		}
+	}
+
+	var pixelFormat uint32
+	pixelFormatValue, ok := params.(map[string]interface{})[PixFmtPixFmt]
+	if !ok {
+		pixelFormat = v4l2PixelFormat.PixelFormat
+	} else {
+		pixelFormat, ok = PixelFormatPixelFormats[fmt.Sprint(pixelFormatValue)]
+		if !ok {
+			return "", errors.NewCommonEdgeXWrapper(nil)
+		}
+	}
+
+	var field uint32
+	fieldValue, ok := params.(map[string]interface{})[PixFmtField]
+	if !ok {
+		field = v4l2PixelFormat.Field
+	} else {
+		field, ok = PixelFormatFields[fmt.Sprint(fieldValue)]
+		if !ok {
+			return "", errors.NewCommonEdgeXWrapper(nil)
+		}
+	}
+
+	var bytesPerLine uint64
+	bytesPerLineValue, ok := params.(map[string]interface{})[PixFmtBytesPerLine]
+	if !ok {
+		bytesPerLine = uint64(v4l2PixelFormat.BytesPerLine)
+	} else {
+		bytesPerLine, err = strconv.ParseUint(bytesPerLineValue.(string), 0, 32)
+		if err != nil {
+			return "", errors.NewCommonEdgeXWrapper(nil)
+		}
+	}
+
+	var sizeImage uint64
+	sizeImageValue, ok := params.(map[string]interface{})[PixFmtSizeImage]
+	if !ok {
+		sizeImage = uint64(v4l2PixelFormat.SizeImage)
+	} else {
+		sizeImage, err = strconv.ParseUint(sizeImageValue.(string), 0, 32)
+		if err != nil {
+			return "", errors.NewCommonEdgeXWrapper(nil)
+		}
+	}
+
+	var colorspace uint32
+	colorspaceValue, ok := params.(map[string]interface{})[PixFmtColorspace]
+	if !ok {
+		colorspace = v4l2PixelFormat.Colorspace
+	} else {
+		colorspace, ok = PixelFormatColorspaces[fmt.Sprint(colorspaceValue)]
+		if !ok {
+			return "", errors.NewCommonEdgeXWrapper(nil)
+		}
+	}
+
+	v4l2PixelFormat.Width = uint32(width)
+	v4l2PixelFormat.Height = uint32(height)
+	v4l2PixelFormat.PixelFormat = pixelFormat
+	v4l2PixelFormat.Field = field
+	v4l2PixelFormat.BytesPerLine = uint32(bytesPerLine)
+	v4l2PixelFormat.SizeImage = uint32(sizeImage)
+	v4l2PixelFormat.Colorspace = uint32(colorspace)
+
+	err = usbDevice.SetPixFormat(v4l2PixelFormat)
+	if err != nil {
+		dev.lc.Errorf("Could not set pixel format, error: %s", err)
+		return "", err
+	}
+
+	return "", err
 }
 
 // SetFrameRate updates the fps on the device side of the service. Note that this won't update the rtsp output stream fps

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -91,6 +91,10 @@ func (dev *Device) StopStreaming() {
 	}
 }
 
+func (dev *Device) SetPixelFormat(usbDevice *usbdevice.Device, params interface{}) (string, error) {
+	return "", nil
+}
+
 // SetFrameRate updates the fps on the device side of the service. Note that this won't update the rtsp output stream fps
 func (dev *Device) SetFrameRate(usbDevice *usbdevice.Device, frameRateNumerator uint32, frameRateDenominator uint32) (string, error) {
 	fps := fmt.Sprintf("%f", float32(frameRateNumerator)/float32(frameRateDenominator))
@@ -115,7 +119,7 @@ func (dev *Device) SetFrameRate(usbDevice *usbdevice.Device, frameRateNumerator 
 		return "", err
 	}
 	// this swaps user-friendly frame rate (frames per second) to
-	// the internally track frame interval (seconds per frame)
+	// the internally tracked frame interval (seconds per frame)
 	origStreamParam.Capture.TimePerFrame.Denominator = frameRateNumerator
 	origStreamParam.Capture.TimePerFrame.Numerator = frameRateDenominator
 	err = usbDevice.SetStreamParam(origStreamParam)
@@ -136,6 +140,24 @@ func (dev *Device) GetFrameRate(usbDevice *usbdevice.Device) (v4l2.Fract, error)
 	fps.Denominator = timePerFrame.Numerator
 	fps.Numerator = timePerFrame.Denominator
 	return fps, nil
+}
+
+func (dev *Device) GetPixelFormat(usbdevice *usbdevice.Device) (interface{}, error) {
+	pixFmt, err := usbdevice.GetPixFormat()
+	if err != nil {
+		return nil, err
+	}
+
+	result := PixelFormat{}
+	result.Height = pixFmt.Height
+	result.Width = pixFmt.Width
+	result.PixelFormat = v4l2.PixelFormats[pixFmt.PixelFormat]
+	result.Field = v4l2.Fields[pixFmt.Field]
+	result.BytesPerLine = pixFmt.BytesPerLine
+	result.SizeImage = pixFmt.SizeImage
+	result.Colorspace = v4l2.Colorspaces[pixFmt.Colorspace]
+
+	return result, nil
 }
 
 func (dev *Device) updateFFmpegOptions(optName, optVal string) {

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -100,7 +100,7 @@ func (dev *Device) SetPixelFormat(usbDevice *usbdevice.Device, params interface{
 		return err
 	}
 
-	widthValue, ok := params.(map[string]interface{})[PixFmtWidth]
+	widthValue, ok := params.(map[string]interface{})[Width]
 	if ok {
 		width, err := strconv.ParseUint(widthValue.(string), 0, 32)
 		if err != nil {
@@ -109,7 +109,7 @@ func (dev *Device) SetPixelFormat(usbDevice *usbdevice.Device, params interface{
 		v4l2PixelFormat.Width = uint32(width)
 	}
 
-	heightValue, ok := params.(map[string]interface{})[PixFmtHeight]
+	heightValue, ok := params.(map[string]interface{})[Height]
 	if ok {
 		height, err := strconv.ParseUint(heightValue.(string), 0, 32)
 		if err != nil {
@@ -118,7 +118,7 @@ func (dev *Device) SetPixelFormat(usbDevice *usbdevice.Device, params interface{
 		v4l2PixelFormat.Height = uint32(height)
 	}
 
-	pixFormatValue, ok := params.(map[string]interface{})[PixFmtPixFmt]
+	pixFormatValue, ok := params.(map[string]interface{})[PixFormat]
 	if ok {
 		pixelFormat, ok := PixelFormatV4l2Mappings[fmt.Sprint(pixFormatValue)]
 		if !ok {
@@ -199,11 +199,23 @@ func (dev *Device) GetPixelFormat(usbDevice *usbdevice.Device) (interface{}, err
 		return nil, err
 	}
 
-	result := PixelFormat{}
-	result.Height = pixFmt.Height
-	result.Width = pixFmt.Width
-	result.PixelFormat = v4l2.PixelFormats[pixFmt.PixelFormat]
-	// Since the v4l2 library has limited pre-defined Pixel Format descriptions
+	result := PixelFormat{
+		Width:        pixFmt.Width,
+		Height:       pixFmt.Height,
+		PixelFormat:  v4l2.PixelFormats[pixFmt.PixelFormat],
+		Field:        v4l2.Fields[pixFmt.Field],
+		BytesPerLine: pixFmt.BytesPerLine,
+		SizeImage:    pixFmt.SizeImage,
+		Colorspace:   v4l2.Colorspaces[pixFmt.Colorspace],
+		Priv:         pixFmt.Priv,
+		Flags:        pixFmt.Flags,
+		YcbcrEnc:     v4l2.YCbCrEncodings[pixFmt.YcbcrEnc],
+		HSVEnc:       v4l2.YCbCrEncodings[pixFmt.HSVEnc],
+		Quantization: v4l2.Quantizations[pixFmt.Quantization],
+		XferFunc:     v4l2.XferFunctions[pixFmt.XferFunc],
+	}
+
+	// Since the go4vl library has limited pre-defined Pixel Format descriptions
 	// get the missing pixel format description using GetFormatDescriptions().
 	if result.PixelFormat == "" {
 		descs, err := usbDevice.GetFormatDescriptions()
@@ -217,16 +229,6 @@ func (dev *Device) GetPixelFormat(usbDevice *usbdevice.Device) (interface{}, err
 			}
 		}
 	}
-	result.Field = v4l2.Fields[pixFmt.Field]
-	result.BytesPerLine = pixFmt.BytesPerLine
-	result.SizeImage = pixFmt.SizeImage
-	result.Colorspace = v4l2.Colorspaces[pixFmt.Colorspace]
-	result.Priv = pixFmt.Priv
-	result.Flags = pixFmt.Flags
-	result.YcbcrEnc = v4l2.YCbCrEncodings[pixFmt.YcbcrEnc]
-	result.HSVEnc = v4l2.YCbCrEncodings[pixFmt.HSVEnc]
-	result.Quantization = v4l2.Quantizations[pixFmt.Quantization]
-	result.XferFunc = v4l2.XferFunctions[pixFmt.XferFunc]
 
 	return result, nil
 }

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -202,6 +202,20 @@ func (dev *Device) GetPixelFormat(usbDevice *usbdevice.Device) (interface{}, err
 	result.Height = pixFmt.Height
 	result.Width = pixFmt.Width
 	result.PixelFormat = v4l2.PixelFormats[pixFmt.PixelFormat]
+	// Since the v4l2 library has limited pre-defined Pixel Format descriptions
+	// get the missing pixel format description using GetFormatDescriptions().
+	if result.PixelFormat == "" {
+		descs, err := usbDevice.GetFormatDescriptions()
+		if err != nil {
+			return nil, err
+		}
+		for _, desc := range descs {
+			if pixFmt.PixelFormat == desc.PixelFormat {
+				result.PixelFormat = desc.Description
+				break
+			}
+		}
+	}
 	result.Field = v4l2.Fields[pixFmt.Field]
 	result.BytesPerLine = pixFmt.BytesPerLine
 	result.SizeImage = pixFmt.SizeImage

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -118,7 +118,7 @@ func (dev *Device) SetPixelFormat(usbDevice *usbdevice.Device, params interface{
 		v4l2PixelFormat.Height = uint32(height)
 	}
 
-	pixFormatValue, ok := params.(map[string]interface{})[PixFormat]
+	pixFormatValue, ok := params.(map[string]interface{})[PixelFormat]
 	if ok {
 		pixelFormat, ok := PixelFormatV4l2Mappings[fmt.Sprint(pixFormatValue)]
 		if !ok {
@@ -199,7 +199,7 @@ func (dev *Device) GetPixelFormat(usbDevice *usbdevice.Device) (interface{}, err
 		return nil, err
 	}
 
-	result := PixelFormat{
+	result := VideoPixelFormat{
 		Width:        pixFmt.Width,
 		Height:       pixFmt.Height,
 		PixelFormat:  v4l2.PixelFormats[pixFmt.PixelFormat],

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -120,7 +120,7 @@ func (dev *Device) SetPixelFormat(usbDevice *usbdevice.Device, params interface{
 
 	pixFormatValue, ok := params.(map[string]interface{})[PixelFormat]
 	if ok {
-		pixelFormat, ok := PixelFormatV4l2Mappings[fmt.Sprint(pixFormatValue)]
+		pixelFormat, ok := PixelFormatV4l2Mappings[pixFormatValue.(string)]
 		if !ok {
 			return fmt.Errorf("invalid input: error parsing pixelFormat for the device %s, error: %s", dev.name, err)
 		}

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -317,6 +317,12 @@ func (d *Driver) ExecuteReadCommands(device *Device, req sdkModels.CommandReques
 			return cv, errorWrapper.CommandError(command, err)
 		}
 		cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeObject, data)
+	case VideoGetPixelFormat:
+		data, err = device.GetPixelFormat(cameraDevice)
+		if err != nil {
+			return cv, errorWrapper.CommandError(command, err)
+		}
+		cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeObject, data)
 	case MetadataDataFormat:
 		data, err = getDataFormat(cameraDevice)
 		if err != nil {
@@ -443,6 +449,16 @@ func (d *Driver) ExecuteWriteCommands(device *Device, req sdkModels.CommandReque
 			return err
 		}
 		d.lc.Infof("Device frame rate set to %s", fps)
+	case VideoSetPixelFormat:
+		params, edgexErr := params[i].ObjectValue()
+		if edgexErr != nil {
+			return errors.NewCommonEdgeXWrapper(edgexErr)
+		}
+		pix, edgexErr := device.SetPixelFormat(cameraDevice, params)
+		if edgexErr != nil {
+			return errors.NewCommonEdgeXWrapper(edgexErr)
+		}
+		d.lc.Infof("Device pixel format set to %s", pix)
 	default:
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("unsupported command %s", command), nil)
 	}

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -320,7 +320,7 @@ func (d *Driver) ExecuteReadCommands(device *Device, req sdkModels.CommandReques
 	case VideoGetPixelFormat:
 		data, err = device.GetPixelFormat(cameraDevice)
 		if err != nil {
-			return cv, errorWrapper.CommandError(command, err)
+			return nil, errorWrapper.CommandError(command, err)
 		}
 		cv, err = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeObject, data)
 	case MetadataDataFormat:

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -454,11 +454,11 @@ func (d *Driver) ExecuteWriteCommands(device *Device, req sdkModels.CommandReque
 		if edgexErr != nil {
 			return errors.NewCommonEdgeXWrapper(edgexErr)
 		}
-		pix, edgexErr := device.SetPixelFormat(cameraDevice, params)
+		edgexErr = device.SetPixelFormat(cameraDevice, params)
 		if edgexErr != nil {
 			return errors.NewCommonEdgeXWrapper(edgexErr)
 		}
-		d.lc.Infof("Device pixel format set to %s", pix)
+		d.lc.Infof("Pixel format set for the device %s", device.name)
 	default:
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("unsupported command %s", command), nil)
 	}

--- a/internal/driver/metadata.go
+++ b/internal/driver/metadata.go
@@ -219,6 +219,21 @@ func getImageFormats(d *usbdevice.Device) (interface{}, error) {
 	return r, nil
 }
 
+func isPixFormatSupported(input uint32, d *usbdevice.Device) (bool, error) {
+	pixformats, err := d.GetFormatDescriptions()
+	if err != nil {
+		return false, err
+	}
+
+	for _, format := range pixformats {
+		if input == format.PixelFormat {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 func getSupportedFrameRateFormats(d *usbdevice.Device) (interface{}, error) {
 	descs, err := d.GetFormatDescriptions()
 	if err != nil {

--- a/internal/driver/metadata.go
+++ b/internal/driver/metadata.go
@@ -144,7 +144,7 @@ func getDataFormat(d *usbdevice.Device) (interface{}, error) {
 		encoding := pixFmt.PixelFormat
 		if interval, err := v4l2.GetFormatFrameInterval(fd, index, encoding, pixFmt.Width, pixFmt.Height); err == nil {
 			intervalCount += 1
-			// this swaps the internally track frame interval (seconds per frame)
+			// this swaps the internally tracked frame interval (seconds per frame)
 			// to user-friendly frame rate (frames per second)
 			frameRates = append(frameRates, v4l2.Fract{
 				Denominator: interval.Interval.Max.Numerator,
@@ -219,21 +219,6 @@ func getImageFormats(d *usbdevice.Device) (interface{}, error) {
 	return r, nil
 }
 
-func isPixFormatSupported(input uint32, d *usbdevice.Device) (bool, error) {
-	pixformats, err := d.GetFormatDescriptions()
-	if err != nil {
-		return false, err
-	}
-
-	for _, format := range pixformats {
-		if input == format.PixelFormat {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
 func getSupportedFrameRateFormats(d *usbdevice.Device) (interface{}, error) {
 	descs, err := d.GetFormatDescriptions()
 	if err != nil {
@@ -267,7 +252,7 @@ func getSupportedFrameRateFormats(d *usbdevice.Device) (interface{}, error) {
 				index := uint32(intervalCount)
 				if interval, err := v4l2.GetFormatFrameInterval(fd, index, encoding, width, height); err == nil {
 					frameInfo.Rates = append(frameInfo.Rates, v4l2.Fract{
-						// this swaps the internally track frame interval (seconds per frame)
+						// this swaps the internally tracked frame interval (seconds per frame)
 						// to user-friendly frame rate (frames per second)
 						Denominator: interval.Interval.Max.Numerator,
 						Numerator:   interval.Interval.Max.Denominator,

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -32,7 +32,7 @@ type FrameRateFormat struct {
 	FrameRates  []FrameInfo
 }
 
-type PixelFormat struct {
+type VideoPixelFormat struct {
 	Width        uint32 `json:"Width"`
 	Height       uint32 `json:"Height"`
 	PixelFormat  string `json:"PixelFormat"`
@@ -59,8 +59,8 @@ var PixelFormatV4l2Mappings = map[string]uint32{
 	"MPEG4": v4l2.PixelFmtMPEG4,
 	"UYVY":  v4l2.PixelFmtUYVY,
 	// pixel formats not supported by go4vl pixel format definitions
-	"BYR2": BYR2PixFmt,
-	"Z16":  DepthZ16PixFmt,
-	"Y8I":  Y8IPixFmt,
-	"Y12I": Y12IPixFmt,
+	"BYR2": PixFmtBYR2,
+	"Z16":  PixFmtDepthZ16,
+	"Y8I":  PixFmtY8I,
+	"Y12I": PixFmtY12I,
 }

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -48,7 +48,7 @@ type PixelFormat struct {
 	XferFunc     string `json:"XferFunc"`
 }
 
-var PixelFormatPixelFormats = map[string]uint32{
+var PixelFormatV4l2Mappings = map[string]uint32{
 	"RGB":   v4l2.PixelFmtRGB24,
 	"GREY":  v4l2.PixelFmtGrey,
 	"YUYV":  v4l2.PixelFmtYUYV,

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -57,4 +57,5 @@ var PixelFormatPixelFormats = map[string]uint32{
 	"MPEG":  v4l2.PixelFmtMPEG,
 	"H264":  v4l2.PixelFmtH264,
 	"MPEG4": v4l2.PixelFmtMPEG4,
+	"UYVY":  v4l2.PixelFmtUYVY,
 }

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -41,3 +41,39 @@ type PixelFormat struct {
 	SizeImage    uint32 `json:"SizeImage"`
 	Colorspace   string `json:"Colorspace"`
 }
+
+var PixelFormatPixelFormats = map[string]uint32{
+	"RGB":   v4l2.PixelFmtRGB24,
+	"GREY":  v4l2.PixelFmtGrey,
+	"YUYV":  v4l2.PixelFmtYUYV,
+	"MJPEG": v4l2.PixelFmtMJPEG,
+	"JPEG":  v4l2.PixelFmtJPEG,
+	"MPEG":  v4l2.PixelFmtMPEG,
+	"H264":  v4l2.PixelFmtH264,
+	"MPEG4": v4l2.PixelFmtMPEG4,
+}
+
+var PixelFormatFields = map[string]uint32{
+	"ANY":       v4l2.FieldAny,
+	"NONE":      v4l2.FieldNone,
+	"TOP":       v4l2.FieldTop,
+	"BOTTOM":    v4l2.FieldBottom,
+	"INT":       v4l2.FieldInterlaced,
+	"SEQTOPBOT": v4l2.FieldInterlacedBottomTop,
+	"SEQBOTTOP": v4l2.FieldInterlacedTopBottom,
+	"ALT":       v4l2.FieldAlternate,
+	"INTTOPBOT": v4l2.FieldInterlacedTopBottom,
+	"INTBOTTOP": v4l2.FieldSequentialBottomTop,
+}
+
+var PixelFormatColorspaces = map[string]uint32{
+	"DEFAULT": v4l2.ColorspaceDefault,
+	"REC709":  v4l2.ColorspaceREC709,
+	"470SBG":  v4l2.Colorspace470SystemBG,
+	"JPEG":    v4l2.ColorspaceJPEG,
+	"SRGB":    v4l2.ColorspaceSRGB,
+	"OPRGB":   v4l2.ColorspaceOPRGB,
+	"BT2020":  v4l2.ColorspaceBT2020,
+	"RAW":     v4l2.ColorspaceRaw,
+	"DCIP3":   v4l2.ColorspaceDCIP3,
+}

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -40,40 +40,21 @@ type PixelFormat struct {
 	BytesPerLine uint32 `json:"BytesPerLine"`
 	SizeImage    uint32 `json:"SizeImage"`
 	Colorspace   string `json:"Colorspace"`
+	Priv         uint32 `json:"Priv"`
+	Flags        uint32 `json:"Flags"`
+	YcbcrEnc     string `json:"YcbcrEnc"`
+	HSVEnc       string `json:"HSVEnc"`
+	Quantization string `json:"Quantization"`
+	XferFunc     string `json:"XferFunc"`
 }
 
 var PixelFormatPixelFormats = map[string]uint32{
 	"RGB":   v4l2.PixelFmtRGB24,
 	"GREY":  v4l2.PixelFmtGrey,
 	"YUYV":  v4l2.PixelFmtYUYV,
-	"MJPEG": v4l2.PixelFmtMJPEG,
+	"MJPG":  v4l2.PixelFmtMJPEG,
 	"JPEG":  v4l2.PixelFmtJPEG,
 	"MPEG":  v4l2.PixelFmtMPEG,
 	"H264":  v4l2.PixelFmtH264,
 	"MPEG4": v4l2.PixelFmtMPEG4,
-}
-
-var PixelFormatFields = map[string]uint32{
-	"ANY":       v4l2.FieldAny,
-	"NONE":      v4l2.FieldNone,
-	"TOP":       v4l2.FieldTop,
-	"BOTTOM":    v4l2.FieldBottom,
-	"INT":       v4l2.FieldInterlaced,
-	"SEQTOPBOT": v4l2.FieldInterlacedBottomTop,
-	"SEQBOTTOP": v4l2.FieldInterlacedTopBottom,
-	"ALT":       v4l2.FieldAlternate,
-	"INTTOPBOT": v4l2.FieldInterlacedTopBottom,
-	"INTBOTTOP": v4l2.FieldSequentialBottomTop,
-}
-
-var PixelFormatColorspaces = map[string]uint32{
-	"DEFAULT": v4l2.ColorspaceDefault,
-	"REC709":  v4l2.ColorspaceREC709,
-	"470SBG":  v4l2.Colorspace470SystemBG,
-	"JPEG":    v4l2.ColorspaceJPEG,
-	"SRGB":    v4l2.ColorspaceSRGB,
-	"OPRGB":   v4l2.ColorspaceOPRGB,
-	"BT2020":  v4l2.ColorspaceBT2020,
-	"RAW":     v4l2.ColorspaceRaw,
-	"DCIP3":   v4l2.ColorspaceDCIP3,
 }

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -31,3 +31,13 @@ type FrameRateFormat struct {
 	Description string
 	FrameRates  []FrameInfo
 }
+
+type PixelFormat struct {
+	Width        uint32 `json:"Width"`
+	Height       uint32 `json:"Height"`
+	PixelFormat  string `json:"PixelFormat"`
+	Field        string `json:"Field"`
+	BytesPerLine uint32 `json:"BytesPerLine"`
+	SizeImage    uint32 `json:"SizeImage"`
+	Colorspace   string `json:"Colorspace"`
+}

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -58,9 +58,9 @@ var PixelFormatV4l2Mappings = map[string]uint32{
 	"H264":  v4l2.PixelFmtH264,
 	"MPEG4": v4l2.PixelFmtMPEG4,
 	"UYVY":  v4l2.PixelFmtUYVY,
-	// pixel formats not directly included as part of v4l2 pixel format definitions
-	"BYR2": 844257602,
-	"Z16":  540422490,
-	"Y8I":  541669465,
-	"Y12I": 1228026201,
+	// pixel formats not supported by go4vl pixel format definitions
+	"BYR2": BYR2PixFmt,
+	"Z16":  DepthZ16PixFmt,
+	"Y8I":  Y8IPixFmt,
+	"Y12I": Y12IPixFmt,
 }

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -58,4 +58,9 @@ var PixelFormatPixelFormats = map[string]uint32{
 	"H264":  v4l2.PixelFmtH264,
 	"MPEG4": v4l2.PixelFmtMPEG4,
 	"UYVY":  v4l2.PixelFmtUYVY,
+	// pixel formats not directly included as part of v4l2 pixel format definitions
+	"BYR2": 844257602,
+	"Z16":  540422490,
+	"Y8I":  541669465,
+	"Y12I": 1228026201,
 }


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Build docker image using `make docker` and deploy all edgex core services along with the usb service.
1. Executing get `PixelFormat` command for a valid camera with a valid path index should give valid result with height, width, pixelFormat and other parameters.
2. Invalid camera or path index (not video streaming path) should give error.
3. Executing set `PixelFormat` command with valid parameters (height, width and pixelFormat) should be successful (200 status code). Postman collection can be referred for example. Execute get command to validate new parameters have been set.
4. Invalid values should give errors.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->