### PR TITLE
fix: rtsp auth server router not initialized properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ prime/
 stage/
 parts/
 squashfs-root/
+
+cmd/mediamtx
+cmd/mediamtx.yml
+cmd/rtsp-simple-server

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -219,9 +219,7 @@ func (d *Driver) StartRTSPCredentialServer() {
 	e := echo.New()
 	e.HideBanner = true
 	e.Server.ReadHeaderTimeout = 5 * time.Second // G112: A configured ReadHeaderTimeout in the http.Server averts a potential Slowloris Attack
-	router := echo.NewRouter(e)
-	router.Add(http.MethodPost, "/rtspauth", d.RTSPCredentialsHandler)
-
+	e.Router().Add(http.MethodPost, "/rtspauth", d.RTSPCredentialsHandler)
 	d.rtspAuthServer = e
 
 	err := e.Start(d.rtspAuthenticationServerUri)
@@ -861,7 +859,7 @@ func (d *Driver) newDevice(name string, protocols map[string]models.ProtocolProp
 	}
 	trans.MediaFile().SetOutputFormat(RtspUriScheme)
 
-	autoStreaming := true
+	autoStreaming := false
 	autoStreamingStr, edgexErr := d.getProtocolProperty(protocols, UsbProtocol, AutoStreaming)
 	if edgexErr != nil {
 		d.lc.Warnf("Protocol property %s not found. Use default value: %v", AutoStreaming, autoStreaming)


### PR DESCRIPTION
and revert autoStreaming to false to maintain backwards compatibility

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [N/A] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [N/A] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Run device-usb service as normal
Make sure to use dockerized rtsp-server for auth config
Post rtsp credentials to /secret
call startstreaming api
expect success

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->