### PR TITLE
fix: none mode being seen as invalid option to RtspServerMode

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -120,15 +120,11 @@ func (d *Driver) Initialize(sdk interfaces.DeviceServiceSDK) error {
 	d.rtspServerMode = RTSPServerMode(strings.ToLower(d.ds.DriverConfigs()[RtspServerMode]))
 	if d.rtspServerMode == "" {
 		d.rtspServerMode = RTSPServerModeInternal
-	} else {
-		if d.rtspServerMode != RTSPServerModeInternal && d.rtspServerMode != RTSPServerModeExternal {
-			return fmt.Errorf("%s value of \"%s\" is invalid. valid options are \"internal\", \"external\", and \"none\"",
-				RtspServerMode, d.rtspServerMode)
-		}
-	}
-
-	if d.rtspServerMode == RTSPServerModeNone {
+	} else if d.rtspServerMode == RTSPServerModeNone {
 		return nil // nothing left to do
+	} else if d.rtspServerMode != RTSPServerModeInternal && d.rtspServerMode != RTSPServerModeExternal {
+		return fmt.Errorf("%s value of \"%s\" is invalid. valid options are \"internal\", \"external\", and \"none\"",
+			RtspServerMode, d.rtspServerMode)
 	}
 
 	rtspAuthenticationServerUri, ok := d.ds.DriverConfigs()[RtspAuthenticationServer]


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->