### PR TITLE
fix: StreamURI values not parsed in external rtsp mode

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -115,10 +115,6 @@ func (d *Driver) Initialize(sdk interfaces.DeviceServiceSDK) error {
 		d.lc.Errorf("failed to register secret update callback: %v", err)
 	}
 
-	if d.rtspServerMode != RTSPServerModeInternal {
-		return nil // nothing left to do
-	}
-
 	rtspServerHostName, ok := d.ds.DriverConfigs()[RtspServerHostName]
 	if !ok {
 		rtspServerHostName = DefaultRtspServerHostName
@@ -134,6 +130,10 @@ func (d *Driver) Initialize(sdk interfaces.DeviceServiceSDK) error {
 	}
 	d.lc.Infof("RTSP TCP port: %s", rtspPort)
 	d.rtspTcpPort = rtspPort
+
+	if d.rtspServerMode != RTSPServerModeInternal {
+		return nil // nothing left to do
+	}
 
 	// check to see if rtsp-simple-server file/binary exists
 	rtspExecutable := d.ds.DriverConfigs()[RtspServerExe]


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [N/A] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

Get code from this pr branch & latest edgex compose main branch

Go to device usb service cmd/res folder, and update configuation.yaml file with below settings
RtspServerMode set to "external"
RtspServerHostName set to remote ip address of system where rtsp server running

Build usb docker image locally with updated configuration file

Go to edgex compose/compose builder, and update add-device-usb-camera.yaml file to use local usb image

from compose builder, run 'make run no-secty ds-usb-camera' - this wills start edgex services and device usb services, also discovers and adds usb cameras to edgex

Execute some generic api like camera info, ensure camera is accessible and it works correctly

Execute ger stream uri, API
Expected behavior: Should give rtsp stream uri with remote ip

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->

Closes #288 