### PR TITLE
refactor: Replace fmt.Sprintf("%v",v) with cast.ToString(v)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/edgexfoundry/go-mod-core-contracts/v4 v4.1.0-dev.12
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/stretchr/testify v1.11.1
+	github.com/spf13/cast v1.9.2
 	github.com/vladimirvivien/go4vl v0.0.5
 	github.com/xfrr/goffmpeg v1.0.0
 )
@@ -96,7 +97,6 @@ require (
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/speps/go-hashids v2.0.0+incompatible // indirect
-	github.com/spf13/cast v1.9.2 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2022-2023 Intel Corporation
-// Copyright (C) 2023 IOTech Ltd
+// Copyright (C) 2023-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -32,6 +32,7 @@ import (
 	sdkModels "github.com/edgexfoundry/device-sdk-go/v4/pkg/models"
 
 	"github.com/labstack/echo/v4"
+	"github.com/spf13/cast"
 	usbDevice "github.com/vladimirvivien/go4vl/device"
 	"github.com/xfrr/goffmpeg/transcoder"
 )
@@ -328,7 +329,7 @@ func (d *Driver) ExecuteReadCommands(device *Device, req sdkModels.CommandReques
 	}
 	defer cameraDevice.Close()
 
-	switch command := fmt.Sprintf("%v", command); command {
+	switch command := cast.ToString(command); command {
 	case MetadataDeviceCapability:
 		data, err = getCapability(cameraDevice)
 		if err != nil {
@@ -1120,7 +1121,7 @@ func (d *Driver) updateDevicePaths(device models.Device) {
 
 func getQueryParameters(req sdkModels.CommandRequest) (url.Values, errors.EdgeX) {
 	urlRawQuery := req.Attributes[UrlRawQuery]
-	queryParams, err := url.ParseQuery(fmt.Sprintf("%v", urlRawQuery))
+	queryParams, err := url.ParseQuery(cast.ToString(urlRawQuery))
 	if err != nil {
 		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("invalid query parameters: %s", urlRawQuery), err)
 	}

--- a/internal/driver/metadata.go
+++ b/internal/driver/metadata.go
@@ -1,6 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2022-2023 Intel Corporation
+// Copyright (C) 2025 IOTEch Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -90,7 +91,7 @@ func getCapability(d *usbdevice.Device) (interface{}, error) {
 }
 
 func getInputStatus(d *usbdevice.Device, index string) (uint32, error) {
-	i, err := strconv.ParseUint(fmt.Sprintf("%v", index), 10, 32)
+	i, err := strconv.ParseUint(index, 10, 32)
 	if err != nil {
 		return 0, fmt.Errorf("could not convert the given %s %s to Uint32", InputIndex, index)
 	}


### PR DESCRIPTION
Replace fmt.Sprintf("%v",v) with cast.ToString(v) to ensure consistent string conversion and avoid scientific notation for large numeric values.

fix: #415 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
